### PR TITLE
Fix CTAD warnings in graph unit tests

### DIFF
--- a/unittest/Modeling/DirectedGraphTest.cpp
+++ b/unittest/Modeling/DirectedGraphTest.cpp
@@ -21,6 +21,10 @@ struct UnwrappedVertex
   VertexProperty property;
 };
 
+// Deduction guide
+template <typename VertexProperty>
+UnwrappedVertex(VertexProperty) -> UnwrappedVertex<VertexProperty>;
+
 template<typename Graph, typename Range>
 std::vector<UnwrappedVertex<typename Graph::VertexProperty>>
 unwrapVertices(const Graph& graph, Range edges)
@@ -52,6 +56,10 @@ struct UnwrappedEdge
   VertexDescriptor to;
   EdgeProperty property;
 };
+
+// Deduction guide
+template <typename VertexDescriptor, typename EdgeProperty>
+UnwrappedEdge(VertexDescriptor, VertexDescriptor, EdgeProperty) -> UnwrappedEdge<VertexDescriptor, EdgeProperty>;
 
 template<typename Graph, typename Range>
 std::vector<UnwrappedEdge<

--- a/unittest/Modeling/DirectedGraphTest.cpp
+++ b/unittest/Modeling/DirectedGraphTest.cpp
@@ -1,20 +1,16 @@
 #include "marco/Modeling/Graph.h"
 #include "llvm/ADT/StringRef.h"
-#include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using namespace ::marco::modeling::internal;
 using namespace ::testing;
 
-template<typename VertexProperty>
-struct UnwrappedVertex
-{
-  UnwrappedVertex(VertexProperty property) : property(property)
-  {
-  }
+template <typename VertexProperty>
+struct UnwrappedVertex {
+  UnwrappedVertex(VertexProperty property) : property(property) {}
 
-  bool operator==(const UnwrappedVertex& other) const
-  {
+  bool operator==(const UnwrappedVertex &other) const {
     return property == other.property;
   }
 
@@ -25,30 +21,25 @@ struct UnwrappedVertex
 template <typename VertexProperty>
 UnwrappedVertex(VertexProperty) -> UnwrappedVertex<VertexProperty>;
 
-template<typename Graph, typename Range>
+template <typename Graph, typename Range>
 std::vector<UnwrappedVertex<typename Graph::VertexProperty>>
-unwrapVertices(const Graph& graph, Range edges)
-{
+unwrapVertices(const Graph &graph, Range edges) {
   std::vector<UnwrappedVertex<typename Graph::VertexProperty>> result;
 
-  for (auto descriptor: edges) {
+  for (auto descriptor : edges) {
     result.emplace_back(graph[descriptor]);
   }
 
   return result;
 }
 
-template<typename VertexDescriptor, typename EdgeProperty>
-struct UnwrappedEdge
-{
-  UnwrappedEdge(
-      VertexDescriptor from, VertexDescriptor to, EdgeProperty property)
-      : from(from), to(to), property(property)
-  {
-  }
+template <typename VertexDescriptor, typename EdgeProperty>
+struct UnwrappedEdge {
+  UnwrappedEdge(VertexDescriptor from, VertexDescriptor to,
+                EdgeProperty property)
+      : from(from), to(to), property(property) {}
 
-  bool operator==(const UnwrappedEdge& other) const
-  {
+  bool operator==(const UnwrappedEdge &other) const {
     return from == other.from && to == other.to && property == other.property;
   }
 
@@ -59,81 +50,56 @@ struct UnwrappedEdge
 
 // Deduction guide
 template <typename VertexDescriptor, typename EdgeProperty>
-UnwrappedEdge(VertexDescriptor, VertexDescriptor, EdgeProperty) -> UnwrappedEdge<VertexDescriptor, EdgeProperty>;
+UnwrappedEdge(VertexDescriptor, VertexDescriptor, EdgeProperty)
+    -> UnwrappedEdge<VertexDescriptor, EdgeProperty>;
 
-template<typename Graph, typename Range>
-std::vector<UnwrappedEdge<
-    typename Graph::VertexDescriptor, typename Graph::EdgeProperty>>
-unwrapEdges(const Graph& graph, Range edges)
-{
-  std::vector<UnwrappedEdge<
-      typename Graph::VertexDescriptor, typename Graph::EdgeProperty>> result;
+template <typename Graph, typename Range>
+std::vector<UnwrappedEdge<typename Graph::VertexDescriptor,
+                          typename Graph::EdgeProperty>>
+unwrapEdges(const Graph &graph, Range edges) {
+  std::vector<UnwrappedEdge<typename Graph::VertexDescriptor,
+                            typename Graph::EdgeProperty>>
+      result;
 
-  for (auto descriptor: edges) {
+  for (auto descriptor : edges) {
     result.emplace_back(descriptor.from, descriptor.to, graph[descriptor]);
   }
 
   return result;
 }
 
-class Vertex
-{
-  public:
-    Vertex(llvm::StringRef name, int value = 0)
-        : name(name.str()), value(value)
-    {
-    }
+class Vertex {
+public:
+  Vertex(llvm::StringRef name, int value = 0)
+      : name(name.str()), value(value) {}
 
-    bool operator==(const Vertex& other) const
-    {
-      return name == other.name;
-    }
+  bool operator==(const Vertex &other) const { return name == other.name; }
 
-    llvm::StringRef getName() const
-    {
-      return name;
-    }
+  llvm::StringRef getName() const { return name; }
 
-    int getValue() const
-    {
-      return value;
-    }
+  int getValue() const { return value; }
 
-  private:
-    std::string name;
-    int value;
+private:
+  std::string name;
+  int value;
 };
 
-class Edge
-{
-  public:
-    Edge(llvm::StringRef name, int value = 0)
-        : name(name.str()), value(value)
-    {
-    }
+class Edge {
+public:
+  Edge(llvm::StringRef name, int value = 0) : name(name.str()), value(value) {}
 
-    bool operator==(const Edge& other) const
-    {
-      return name == other.name;
-    }
+  bool operator==(const Edge &other) const { return name == other.name; }
 
-    llvm::StringRef getName() const
-    {
-      return name;
-    }
+  llvm::StringRef getName() const { return name; }
 
-    int getValue() const
-    {
-      return value;
-    }
+  int getValue() const { return value; }
 
-  private:
-    std::string name;
-    int value;
+private:
+  std::string name;
+  int value;
 };
 
-TEST(DirectedGraph, moveConstructor)
-{
+TEST(DirectedGraph, moveConstructor) {
   DirectedGraph<Vertex, Edge> first;
   auto x = first.addVertex(Vertex("x"));
   auto y = first.addVertex(Vertex("y"));
@@ -144,8 +110,7 @@ TEST(DirectedGraph, moveConstructor)
   EXPECT_EQ(second.edgesCount(), 1);
 }
 
-TEST(DirectedGraph, moveAssignmentOperator)
-{
+TEST(DirectedGraph, moveAssignmentOperator) {
   DirectedGraph<Vertex, Edge> first;
   auto x = first.addVertex(Vertex("x"));
   auto y = first.addVertex(Vertex("y"));
@@ -158,15 +123,13 @@ TEST(DirectedGraph, moveAssignmentOperator)
   EXPECT_EQ(second.edgesCount(), 1);
 }
 
-TEST(DirectedGraph, addVertex)
-{
+TEST(DirectedGraph, addVertex) {
   DirectedGraph<Vertex, Edge> graph;
   auto x = graph.addVertex(Vertex("x"));
   EXPECT_EQ(graph[x].getName(), "x");
 }
 
-TEST(DirectedGraph, vertices)
-{
+TEST(DirectedGraph, vertices) {
   DirectedGraph<Vertex, Edge> graph;
 
   Vertex x("x");
@@ -180,14 +143,11 @@ TEST(DirectedGraph, vertices)
   auto vertices = llvm::make_range(graph.verticesBegin(), graph.verticesEnd());
 
   EXPECT_THAT(unwrapVertices(graph, vertices),
-      UnorderedElementsAre(
-          UnwrappedVertex(x),
-          UnwrappedVertex(y),
-          UnwrappedVertex(z)));
+              UnorderedElementsAre(UnwrappedVertex(x), UnwrappedVertex(y),
+                                   UnwrappedVertex(z)));
 }
 
-TEST(DirectedGraph, filteredVertices)
-{
+TEST(DirectedGraph, filteredVertices) {
   DirectedGraph<Vertex, Edge> graph;
 
   Vertex x("x", 1);
@@ -198,20 +158,18 @@ TEST(DirectedGraph, filteredVertices)
   graph.addVertex(y);
   graph.addVertex(z);
 
-  auto filter = [](const Vertex& vertex) -> bool {
+  auto filter = [](const Vertex &vertex) -> bool {
     return vertex.getValue() == 1;
   };
 
-  auto vertices =  llvm::make_range(graph.verticesBegin(filter), graph.verticesEnd(filter));
+  auto vertices =
+      llvm::make_range(graph.verticesBegin(filter), graph.verticesEnd(filter));
 
   EXPECT_THAT(unwrapVertices(graph, vertices),
-      UnorderedElementsAre(
-                  UnwrappedVertex(x),
-                  UnwrappedVertex(z)));
+              UnorderedElementsAre(UnwrappedVertex(x), UnwrappedVertex(z)));
 }
 
-TEST(DirectedGraph, addEdge)
-{
+TEST(DirectedGraph, addEdge) {
   DirectedGraph<Vertex, Edge> graph;
 
   auto x = graph.addVertex(Vertex("x"));
@@ -221,8 +179,7 @@ TEST(DirectedGraph, addEdge)
   EXPECT_EQ(graph[e1].getName(), "e1");
 }
 
-TEST(DirectedGraph, outgoingEdges)
-{
+TEST(DirectedGraph, outgoingEdges) {
   DirectedGraph<Vertex, Edge> graph;
 
   auto x = graph.addVertex(Vertex("x"));
@@ -240,31 +197,27 @@ TEST(DirectedGraph, outgoingEdges)
   Edge e4("e4");
   graph.addEdge(y, z, e4);
 
-  auto xEdges = llvm::make_range(
-      graph.outgoingEdgesBegin(x),
-      graph.outgoingEdgesEnd(x));
+  auto xEdges =
+      llvm::make_range(graph.outgoingEdgesBegin(x), graph.outgoingEdgesEnd(x));
 
   EXPECT_THAT(unwrapEdges(graph, xEdges),
-      UnorderedElementsAre(UnwrappedEdge(x, y, e1),
-          UnwrappedEdge(x, y, e2),
-          UnwrappedEdge(x, z, e3)));
+              UnorderedElementsAre(UnwrappedEdge(x, y, e1),
+                                   UnwrappedEdge(x, y, e2),
+                                   UnwrappedEdge(x, z, e3)));
 
-  auto yEdges = llvm::make_range(
-      graph.outgoingEdgesBegin(y),
-      graph.outgoingEdgesEnd(y));
+  auto yEdges =
+      llvm::make_range(graph.outgoingEdgesBegin(y), graph.outgoingEdgesEnd(y));
 
   EXPECT_THAT(unwrapEdges(graph, yEdges),
-      UnorderedElementsAre(UnwrappedEdge(y, z, e4)));
+              UnorderedElementsAre(UnwrappedEdge(y, z, e4)));
 
-  auto zEdges = llvm::make_range(
-      graph.outgoingEdgesBegin(z),
-      graph.outgoingEdgesEnd(z));
+  auto zEdges =
+      llvm::make_range(graph.outgoingEdgesBegin(z), graph.outgoingEdgesEnd(z));
 
   EXPECT_THAT(unwrapEdges(graph, zEdges), IsEmpty());
 }
 
-TEST(DirectedGraph, filteredOutgoingEdges)
-{
+TEST(DirectedGraph, filteredOutgoingEdges) {
   DirectedGraph<Vertex, Edge> graph;
 
   auto x = graph.addVertex(Vertex("x"));
@@ -285,34 +238,28 @@ TEST(DirectedGraph, filteredOutgoingEdges)
   Edge e5("e5", 0);
   graph.addEdge(z, x, e5);
 
-  auto filter = [](const Edge& edge) -> bool {
-    return edge.getValue() == 1;
-  };
+  auto filter = [](const Edge &edge) -> bool { return edge.getValue() == 1; };
 
-  auto xEdges = llvm::make_range(
-      graph.outgoingEdgesBegin(x, filter),
-      graph.outgoingEdgesEnd(x, filter));
+  auto xEdges = llvm::make_range(graph.outgoingEdgesBegin(x, filter),
+                                 graph.outgoingEdgesEnd(x, filter));
 
-  EXPECT_THAT(unwrapEdges(graph, xEdges),
-      UnorderedElementsAre(UnwrappedEdge(x, y, e1),
-          UnwrappedEdge(x, z, e3)));
+  EXPECT_THAT(
+      unwrapEdges(graph, xEdges),
+      UnorderedElementsAre(UnwrappedEdge(x, y, e1), UnwrappedEdge(x, z, e3)));
 
-  auto yEdges = llvm::make_range(
-      graph.outgoingEdgesBegin(y, filter),
-      graph.outgoingEdgesEnd(y, filter));
+  auto yEdges = llvm::make_range(graph.outgoingEdgesBegin(y, filter),
+                                 graph.outgoingEdgesEnd(y, filter));
 
   EXPECT_THAT(unwrapEdges(graph, yEdges),
-      UnorderedElementsAre(UnwrappedEdge(y, z, e4)));
+              UnorderedElementsAre(UnwrappedEdge(y, z, e4)));
 
-  auto zEdges = llvm::make_range(
-      graph.outgoingEdgesBegin(z, filter),
-      graph.outgoingEdgesEnd(z, filter));
+  auto zEdges = llvm::make_range(graph.outgoingEdgesBegin(z, filter),
+                                 graph.outgoingEdgesEnd(z, filter));
 
   EXPECT_THAT(unwrapEdges(graph, zEdges), IsEmpty());
 }
 
-TEST(DirectedGraph, edges)
-{
+TEST(DirectedGraph, edges) {
   DirectedGraph<Vertex, Edge> graph;
 
   auto x = graph.addVertex(Vertex("x"));
@@ -332,15 +279,13 @@ TEST(DirectedGraph, edges)
 
   auto edges = llvm::make_range(graph.edgesBegin(), graph.edgesEnd());
 
-  EXPECT_THAT(unwrapEdges(graph, edges),
-      UnorderedElementsAre(UnwrappedEdge(x, y, e1),
-          UnwrappedEdge(x, y, e2),
-          UnwrappedEdge(x, z, e3),
-          UnwrappedEdge(y, z, e4)));
+  EXPECT_THAT(
+      unwrapEdges(graph, edges),
+      UnorderedElementsAre(UnwrappedEdge(x, y, e1), UnwrappedEdge(x, y, e2),
+                           UnwrappedEdge(x, z, e3), UnwrappedEdge(y, z, e4)));
 }
 
-TEST(DirectedGraph, filteredEdges)
-{
+TEST(DirectedGraph, filteredEdges) {
   DirectedGraph<Vertex, Edge> graph;
 
   auto x = graph.addVertex(Vertex("x"));
@@ -358,22 +303,18 @@ TEST(DirectedGraph, filteredEdges)
   Edge e4("e4", 1);
   graph.addEdge(y, z, e4);
 
-  auto filter = [](const Edge& edge) -> bool {
-    return edge.getValue() == 1;
-  };
+  auto filter = [](const Edge &edge) -> bool { return edge.getValue() == 1; };
 
-  auto edges = llvm::make_range(
-      graph.edgesBegin(filter),
-      graph.edgesEnd(filter));
+  auto edges =
+      llvm::make_range(graph.edgesBegin(filter), graph.edgesEnd(filter));
 
   EXPECT_THAT(unwrapEdges(graph, edges),
-      UnorderedElementsAre(UnwrappedEdge(x, y, e1),
-          UnwrappedEdge(x, z, e3),
-          UnwrappedEdge(y, z, e4)));
+              UnorderedElementsAre(UnwrappedEdge(x, y, e1),
+                                   UnwrappedEdge(x, z, e3),
+                                   UnwrappedEdge(y, z, e4)));
 }
 
-TEST(DirectedGraph, clone)
-{
+TEST(DirectedGraph, clone) {
   DirectedGraph<Vertex, Edge> first;
   auto x = first.addVertex(Vertex("x"));
   auto y = first.addVertex(Vertex("y"));

--- a/unittest/Modeling/UndirectedGraphTest.cpp
+++ b/unittest/Modeling/UndirectedGraphTest.cpp
@@ -1,20 +1,16 @@
 #include "marco/Modeling/Graph.h"
 #include "llvm/ADT/StringRef.h"
-#include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using namespace ::marco::modeling::internal;
 using namespace ::testing;
 
-template<typename VertexProperty>
-struct UnwrappedVertex
-{
-  UnwrappedVertex(VertexProperty property) : property(property)
-  {
-  }
+template <typename VertexProperty>
+struct UnwrappedVertex {
+  UnwrappedVertex(VertexProperty property) : property(property) {}
 
-  bool operator==(const UnwrappedVertex& other) const
-  {
+  bool operator==(const UnwrappedVertex &other) const {
     return property == other.property;
   }
 
@@ -25,31 +21,28 @@ struct UnwrappedVertex
 template <typename VertexProperty>
 UnwrappedVertex(VertexProperty) -> UnwrappedVertex<VertexProperty>;
 
-template<typename Graph, typename Range>
+template <typename Graph, typename Range>
 std::vector<UnwrappedVertex<typename Graph::VertexProperty>>
-unwrapVertices(const Graph& graph, Range edges)
-{
+unwrapVertices(const Graph &graph, Range edges) {
   std::vector<UnwrappedVertex<typename Graph::VertexProperty>> result;
 
-  for (auto descriptor: edges) {
+  for (auto descriptor : edges) {
     result.emplace_back(graph[descriptor]);
   }
 
   return result;
 }
 
-template<typename VertexDescriptor, typename EdgeProperty>
-struct UnwrappedEdge
-{
-  UnwrappedEdge(VertexDescriptor from, VertexDescriptor to, EdgeProperty property)
-      : from(from), to(to), property(property)
-  {
-  }
+template <typename VertexDescriptor, typename EdgeProperty>
+struct UnwrappedEdge {
+  UnwrappedEdge(VertexDescriptor from, VertexDescriptor to,
+                EdgeProperty property)
+      : from(from), to(to), property(property) {}
 
-  bool operator==(const UnwrappedEdge& other) const
-  {
+  bool operator==(const UnwrappedEdge &other) const {
     return (property == other.property) &&
-        ((from == other.from && to == other.to) || (from == other.to && to == other.from));
+           ((from == other.from && to == other.to) ||
+            (from == other.to && to == other.from));
   }
 
   VertexDescriptor from;
@@ -59,77 +52,56 @@ struct UnwrappedEdge
 
 // Deduction guide
 template <typename VertexDescriptor, typename EdgeProperty>
-UnwrappedEdge(VertexDescriptor, VertexDescriptor, EdgeProperty) -> UnwrappedEdge<VertexDescriptor, EdgeProperty>;
+UnwrappedEdge(VertexDescriptor, VertexDescriptor, EdgeProperty)
+    -> UnwrappedEdge<VertexDescriptor, EdgeProperty>;
 
-template<typename Graph, typename Range>
-std::vector<UnwrappedEdge<typename Graph::VertexDescriptor, typename Graph::EdgeProperty>>
-unwrapEdges(const Graph& graph, Range edges)
-{
-  std::vector<UnwrappedEdge<typename Graph::VertexDescriptor, typename Graph::EdgeProperty>> result;
+template <typename Graph, typename Range>
+std::vector<UnwrappedEdge<typename Graph::VertexDescriptor,
+                          typename Graph::EdgeProperty>>
+unwrapEdges(const Graph &graph, Range edges) {
+  std::vector<UnwrappedEdge<typename Graph::VertexDescriptor,
+                            typename Graph::EdgeProperty>>
+      result;
 
-  for (auto descriptor: edges) {
+  for (auto descriptor : edges) {
     result.emplace_back(descriptor.from, descriptor.to, graph[descriptor]);
   }
 
   return result;
 }
 
-class Vertex
-{
-  public:
-    Vertex(llvm::StringRef name, int value = 0) : name(name.str()), value(value)
-    {
-    }
+class Vertex {
+public:
+  Vertex(llvm::StringRef name, int value = 0)
+      : name(name.str()), value(value) {}
 
-    bool operator==(const Vertex& other) const
-    {
-      return name == other.name;
-    }
+  bool operator==(const Vertex &other) const { return name == other.name; }
 
-    llvm::StringRef getName() const
-    {
-      return name;
-    }
+  llvm::StringRef getName() const { return name; }
 
-    int getValue() const
-    {
-      return value;
-    }
+  int getValue() const { return value; }
 
-  private:
-    std::string name;
-    int value;
+private:
+  std::string name;
+  int value;
 };
 
-class Edge
-{
-  public:
-    Edge(llvm::StringRef name, int value = 0) : name(name.str()), value(value)
-    {
-    }
+class Edge {
+public:
+  Edge(llvm::StringRef name, int value = 0) : name(name.str()), value(value) {}
 
-    bool operator==(const Edge& other) const
-    {
-      return name == other.name;
-    }
+  bool operator==(const Edge &other) const { return name == other.name; }
 
-    llvm::StringRef getName() const
-    {
-      return name;
-    }
+  llvm::StringRef getName() const { return name; }
 
-    int getValue() const
-    {
-      return value;
-    }
+  int getValue() const { return value; }
 
-  private:
-    std::string name;
-    int value;
+private:
+  std::string name;
+  int value;
 };
 
-TEST(UndirectedGraph, moveConstructor)
-{
+TEST(UndirectedGraph, moveConstructor) {
   UndirectedGraph<Vertex, Edge> first;
   auto x = first.addVertex(Vertex("x"));
   auto y = first.addVertex(Vertex("y"));
@@ -140,8 +112,7 @@ TEST(UndirectedGraph, moveConstructor)
   EXPECT_EQ(second.edgesCount(), 1);
 }
 
-TEST(UndirectedGraph, moveAssignmentOperator)
-{
+TEST(UndirectedGraph, moveAssignmentOperator) {
   UndirectedGraph<Vertex, Edge> first;
   auto x = first.addVertex(Vertex("x"));
   auto y = first.addVertex(Vertex("y"));
@@ -154,15 +125,13 @@ TEST(UndirectedGraph, moveAssignmentOperator)
   EXPECT_EQ(second.edgesCount(), 1);
 }
 
-TEST(UndirectedGraph, addVertex)
-{
+TEST(UndirectedGraph, addVertex) {
   UndirectedGraph<Vertex, Edge> graph;
   auto x = graph.addVertex(Vertex("x"));
   EXPECT_EQ(graph[x].getName(), "x");
 }
 
-TEST(UndirectedGraph, vertices)
-{
+TEST(UndirectedGraph, vertices) {
   UndirectedGraph<Vertex, Edge> graph;
 
   Vertex x("x");
@@ -176,13 +145,11 @@ TEST(UndirectedGraph, vertices)
   auto vertices = llvm::make_range(graph.verticesBegin(), graph.verticesEnd());
 
   EXPECT_THAT(unwrapVertices(graph, vertices),
-      UnorderedElementsAre(UnwrappedVertex(x),
-          UnwrappedVertex(y),
-          UnwrappedVertex(z)));
+              UnorderedElementsAre(UnwrappedVertex(x), UnwrappedVertex(y),
+                                   UnwrappedVertex(z)));
 }
 
-TEST(UndirectedGraph, filteredVertices)
-{
+TEST(UndirectedGraph, filteredVertices) {
   UndirectedGraph<Vertex, Edge> graph;
 
   Vertex x("x", 1);
@@ -193,19 +160,18 @@ TEST(UndirectedGraph, filteredVertices)
   graph.addVertex(y);
   graph.addVertex(z);
 
-  auto filter = [](const Vertex& vertex) -> bool {
+  auto filter = [](const Vertex &vertex) -> bool {
     return vertex.getValue() == 1;
   };
 
-  auto vertices = llvm::make_range(graph.verticesBegin(filter), graph.verticesEnd(filter));
+  auto vertices =
+      llvm::make_range(graph.verticesBegin(filter), graph.verticesEnd(filter));
 
   EXPECT_THAT(unwrapVertices(graph, vertices),
-      UnorderedElementsAre(UnwrappedVertex(x),
-          UnwrappedVertex(z)));
+              UnorderedElementsAre(UnwrappedVertex(x), UnwrappedVertex(z)));
 }
 
-TEST(UndirectedGraph, addEdge)
-{
+TEST(UndirectedGraph, addEdge) {
   UndirectedGraph<Vertex, Edge> graph;
 
   auto x = graph.addVertex(Vertex("x"));
@@ -215,8 +181,7 @@ TEST(UndirectedGraph, addEdge)
   EXPECT_EQ(graph[e1].getName(), "e1");
 }
 
-TEST(UndirectedGraph, outgoingEdges)
-{
+TEST(UndirectedGraph, outgoingEdges) {
   UndirectedGraph<Vertex, Edge> graph;
 
   auto x = graph.addVertex(Vertex("x"));
@@ -234,35 +199,31 @@ TEST(UndirectedGraph, outgoingEdges)
   Edge e4("e4");
   graph.addEdge(y, z, e4);
 
-  auto xEdges = llvm::make_range(
-      graph.outgoingEdgesBegin(x),
-      graph.outgoingEdgesEnd(x));
+  auto xEdges =
+      llvm::make_range(graph.outgoingEdgesBegin(x), graph.outgoingEdgesEnd(x));
 
-  EXPECT_THAT(unwrapEdges(graph,xEdges),
-      UnorderedElementsAre(UnwrappedEdge(x, y, e1),
-          UnwrappedEdge(x, y, e2),
-          UnwrappedEdge(x, z, e3)));
+  EXPECT_THAT(unwrapEdges(graph, xEdges),
+              UnorderedElementsAre(UnwrappedEdge(x, y, e1),
+                                   UnwrappedEdge(x, y, e2),
+                                   UnwrappedEdge(x, z, e3)));
 
-  auto yEdges = llvm::make_range(
-      graph.outgoingEdgesBegin(y),
-      graph.outgoingEdgesEnd(y));
+  auto yEdges =
+      llvm::make_range(graph.outgoingEdgesBegin(y), graph.outgoingEdgesEnd(y));
 
   EXPECT_THAT(unwrapEdges(graph, yEdges),
-      UnorderedElementsAre(UnwrappedEdge(y, x, e1),
-          UnwrappedEdge(y, x, e2),
-          UnwrappedEdge(y, z, e4)));
+              UnorderedElementsAre(UnwrappedEdge(y, x, e1),
+                                   UnwrappedEdge(y, x, e2),
+                                   UnwrappedEdge(y, z, e4)));
 
-  auto zEdges = llvm::make_range(
-      graph.outgoingEdgesBegin(z),
-      graph.outgoingEdgesEnd(z));
+  auto zEdges =
+      llvm::make_range(graph.outgoingEdgesBegin(z), graph.outgoingEdgesEnd(z));
 
-  EXPECT_THAT(unwrapEdges(graph, zEdges),
-      UnorderedElementsAre(UnwrappedEdge(z, x, e3),
-          UnwrappedEdge(z, y, e4)));
+  EXPECT_THAT(
+      unwrapEdges(graph, zEdges),
+      UnorderedElementsAre(UnwrappedEdge(z, x, e3), UnwrappedEdge(z, y, e4)));
 }
 
-TEST(UndirectedGraph, filteredOutgoingEdges)
-{
+TEST(UndirectedGraph, filteredOutgoingEdges) {
   UndirectedGraph<Vertex, Edge> graph;
 
   auto x = graph.addVertex(Vertex("x"));
@@ -283,37 +244,31 @@ TEST(UndirectedGraph, filteredOutgoingEdges)
   Edge e5("e5", 0);
   graph.addEdge(z, x, e5);
 
-  auto filter = [](const Edge& edge) -> bool {
-    return edge.getValue() == 1;
-  };
+  auto filter = [](const Edge &edge) -> bool { return edge.getValue() == 1; };
 
-  auto xEdges = llvm::make_range(
-      graph.outgoingEdgesBegin(x, filter),
-      graph.outgoingEdgesEnd(x, filter));
+  auto xEdges = llvm::make_range(graph.outgoingEdgesBegin(x, filter),
+                                 graph.outgoingEdgesEnd(x, filter));
 
-  EXPECT_THAT(unwrapEdges(graph, xEdges),
-      UnorderedElementsAre(UnwrappedEdge(x, y, e1),
-          UnwrappedEdge(x, z, e3)));
+  EXPECT_THAT(
+      unwrapEdges(graph, xEdges),
+      UnorderedElementsAre(UnwrappedEdge(x, y, e1), UnwrappedEdge(x, z, e3)));
 
-  auto yEdges = llvm::make_range(
-      graph.outgoingEdgesBegin(y, filter),
-      graph.outgoingEdgesEnd(y, filter));
+  auto yEdges = llvm::make_range(graph.outgoingEdgesBegin(y, filter),
+                                 graph.outgoingEdgesEnd(y, filter));
 
-  EXPECT_THAT(unwrapEdges(graph, yEdges),
-      UnorderedElementsAre(UnwrappedEdge(y, x, e1),
-          UnwrappedEdge(y, z, e4)));
+  EXPECT_THAT(
+      unwrapEdges(graph, yEdges),
+      UnorderedElementsAre(UnwrappedEdge(y, x, e1), UnwrappedEdge(y, z, e4)));
 
-  auto zEdges = llvm::make_range(
-      graph.outgoingEdgesBegin(z, filter),
-      graph.outgoingEdgesEnd(z, filter));
+  auto zEdges = llvm::make_range(graph.outgoingEdgesBegin(z, filter),
+                                 graph.outgoingEdgesEnd(z, filter));
 
-  EXPECT_THAT(unwrapEdges(graph, zEdges),
-      UnorderedElementsAre(UnwrappedEdge(z, x, e3),
-          UnwrappedEdge(z, y, e4)));
+  EXPECT_THAT(
+      unwrapEdges(graph, zEdges),
+      UnorderedElementsAre(UnwrappedEdge(z, x, e3), UnwrappedEdge(z, y, e4)));
 }
 
-TEST(UndirectedGraph, edges)
-{
+TEST(UndirectedGraph, edges) {
   UndirectedGraph<Vertex, Edge> graph;
 
   auto x = graph.addVertex(Vertex("x"));
@@ -333,15 +288,13 @@ TEST(UndirectedGraph, edges)
 
   auto edges = llvm::make_range(graph.edgesBegin(), graph.edgesEnd());
 
-  EXPECT_THAT(unwrapEdges(graph, edges),
-      UnorderedElementsAre(UnwrappedEdge(x, y, e1),
-          UnwrappedEdge(x, y, e2),
-          UnwrappedEdge(x, z, e3),
-          UnwrappedEdge(y, z, e4)));
+  EXPECT_THAT(
+      unwrapEdges(graph, edges),
+      UnorderedElementsAre(UnwrappedEdge(x, y, e1), UnwrappedEdge(x, y, e2),
+                           UnwrappedEdge(x, z, e3), UnwrappedEdge(y, z, e4)));
 }
 
-TEST(UndirectedGraph, filteredEdges)
-{
+TEST(UndirectedGraph, filteredEdges) {
   UndirectedGraph<Vertex, Edge> graph;
 
   auto x = graph.addVertex(Vertex("x"));
@@ -359,22 +312,18 @@ TEST(UndirectedGraph, filteredEdges)
   Edge e4("e4", 1);
   graph.addEdge(y, z, e4);
 
-  auto filter = [](const Edge& edge) -> bool {
-    return edge.getValue() == 1;
-  };
+  auto filter = [](const Edge &edge) -> bool { return edge.getValue() == 1; };
 
-  auto edges = llvm::make_range(
-      graph.edgesBegin(filter),
-      graph.edgesEnd(filter));
+  auto edges =
+      llvm::make_range(graph.edgesBegin(filter), graph.edgesEnd(filter));
 
   EXPECT_THAT(unwrapEdges(graph, edges),
-      UnorderedElementsAre(UnwrappedEdge(x, y, e1),
-          UnwrappedEdge(x, z, e3),
-          UnwrappedEdge(y, z, e4)));
+              UnorderedElementsAre(UnwrappedEdge(x, y, e1),
+                                   UnwrappedEdge(x, z, e3),
+                                   UnwrappedEdge(y, z, e4)));
 }
 
-TEST(UndirectedGraph, clone)
-{
+TEST(UndirectedGraph, clone) {
   UndirectedGraph<Vertex, Edge> first;
   auto x = first.addVertex(Vertex("x"));
   auto y = first.addVertex(Vertex("y"));

--- a/unittest/Modeling/UndirectedGraphTest.cpp
+++ b/unittest/Modeling/UndirectedGraphTest.cpp
@@ -21,6 +21,10 @@ struct UnwrappedVertex
   VertexProperty property;
 };
 
+// Deduction guide
+template <typename VertexProperty>
+UnwrappedVertex(VertexProperty) -> UnwrappedVertex<VertexProperty>;
+
 template<typename Graph, typename Range>
 std::vector<UnwrappedVertex<typename Graph::VertexProperty>>
 unwrapVertices(const Graph& graph, Range edges)
@@ -52,6 +56,10 @@ struct UnwrappedEdge
   VertexDescriptor to;
   EdgeProperty property;
 };
+
+// Deduction guide
+template <typename VertexDescriptor, typename EdgeProperty>
+UnwrappedEdge(VertexDescriptor, VertexDescriptor, EdgeProperty) -> UnwrappedEdge<VertexDescriptor, EdgeProperty>;
 
 template<typename Graph, typename Range>
 std::vector<UnwrappedEdge<typename Graph::VertexDescriptor, typename Graph::EdgeProperty>>


### PR DESCRIPTION
Adds deduction guides for templates that generate a ton of warnings when building.