### PR TITLE
Strategized, type-erased graph dumper

### DIFF
--- a/include/public/marco/Modeling/GraphDumper.h
+++ b/include/public/marco/Modeling/GraphDumper.h
@@ -1,0 +1,269 @@
+#ifndef MARCO_MODELING_GRAPHDUMPER_H
+#define MARCO_MODELING_GRAPHDUMPER_H
+
+#include "marco/Modeling/Dumpable.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include <functional>
+#include <utility>
+
+namespace marco::modeling::internal {
+namespace impl {
+
+//==----------------------------------------------------------------------===//
+// Example Backend
+//
+// Except for `GraphType`, all subsequent template parameters will be
+// wrapped functors. See `PrinterWrapper` for details.
+// The wrapped functors, themselves, behave like functors.
+//==----------------------------------------------------------------------===//
+
+// template <class GraphType, class VPrinter, class EPrinter>
+// class GraphDumperTestBackend {
+// public:
+//   using VertexDescriptor = typename GraphType::VertexDescriptor;
+//   using EdgeDescriptor = typename GraphType::EdgeDescriptor;
+//
+//   using VertexProperty = typename GraphType::VertexProperty;
+//   using EdgeProperty = typename GraphType::EdgeProperty;
+//
+//   // These two overloads exist to allow for default behavior when
+//   // the GraphDumper is invoked without an edge printer.
+//   void dump(llvm::raw_ostream &os, VPrinter &&vp, EPrinter &&ep) const {
+//     GraphDumperTestBackend dumper(graph);
+//     dumper.dumpImpl(os, std::forward<VPrinter>(vp),
+//     std::forward<EPrinter>(ep));
+//   }
+//
+//   void dump(llvm::raw_ostream &os, VPrinter &&vp) const {
+//     dumpImpl(os, std::forward<VPrinter>(vp), nullptr);
+//   }
+//
+//   // The main implementation happens here.
+//   // Use the graph to build the representation needed for the backend.
+//   // Use the `llvm::raw_ostream` object passed to insert into the correct
+//   // stream.
+//   void dumpImpl(llvm::raw_ostream &os, VPrinter &&vp, EPrinter &&ep) {
+//     for (auto eIt = graph->edgesBegin(); eIt != graph->edgesEnd(); eIt++) {
+//
+//       auto edgeDescriptor = *eIt;
+//
+//       const auto fromVertexDescriptor = edgeDescriptor.from;
+//       const auto toVertexDescriptor = edgeDescriptor.to;
+//
+//       const auto fromVertexWrapper = *fromVertexDescriptor.value;
+//       const auto toVertexWrapper = *toVertexDescriptor.value;
+//
+//       const auto fromVertex = *(fromVertexWrapper);
+//       const auto toVertex = *(toVertexWrapper);
+//
+//       vp(fromVertex, os);
+//
+//       if constexpr (ep.isValid()) {
+//         ep(***edgeDescriptor.value, os);
+//       } else {
+//         os << " --> ";
+//       }
+//       vp(toVertex, os);
+//       os << "\n";
+//     }
+//   }
+//
+//   GraphDumperTestBackend(GraphType *graph) : graph{graph} {}
+//
+// private:
+//   GraphType *graph;
+// }
+
+//===----------------------------------------------------------------------==//
+// Printer Wrapper
+//-----------------------------------------------------------------------------
+// A simple utility wrapper that wraps all passed printer functors.
+// Allows for both dynamic and compile-time checking of whether the passed
+// functor is valid.
+//===----------------------------------------------------------------------==//
+template <class Functor>
+class PrinterWrapper {
+private:
+  Functor f;
+
+public:
+  constexpr PrinterWrapper(Functor &&f) : f{std::forward<Functor>(f)} {}
+
+  constexpr bool isValid() const { return true; }
+
+  template <class... Args>
+  void operator()(Args &&...args) {
+    f(std::forward<Args>(args)...);
+  }
+};
+
+template <>
+class PrinterWrapper<std::nullptr_t> {
+private:
+public:
+  constexpr PrinterWrapper(std::nullptr_t) {}
+
+  constexpr bool isValid() const { return false; }
+
+  template <class... Args>
+  void operator()(Args &&...args) {
+    (void)sizeof...(args);
+  }
+};
+
+//==----------------------------------------------------------------------===//
+// Mermaid Backend
+//==----------------------------------------------------------------------===//
+
+template <class GraphType, class VPrinter,
+          class EPrinter = std::function<void()>>
+struct GraphDumperMermaidBackend {
+  using VertexDescriptor = typename GraphType::VertexDescriptor;
+  using EdgeDescriptor = typename GraphType::EdgeDescriptor;
+
+  using VertexProperty = typename GraphType::VertexProperty;
+  using EdgeProperty = typename GraphType::EdgeProperty;
+
+  GraphDumperMermaidBackend(GraphType *graph) : graph{graph} {}
+
+  void dump(llvm::raw_ostream &os, VPrinter &&vp, EPrinter &&ep) const {
+    GraphDumperMermaidBackend dumper(graph);
+    dumper.dumpImpl(os, std::forward<VPrinter>(vp), std::forward<EPrinter>(ep));
+  }
+
+  void dump(llvm::raw_ostream &os, VPrinter &&vp) const {
+    GraphDumperMermaidBackend dumper(graph);
+    dumper.dumpImpl(os, std::forward<VPrinter>(vp), nullptr);
+  }
+
+  std::string indexToStringIdentifier(int idx) {
+    std::string result;
+    constexpr int base = 26;
+
+    while (idx >= 0) {
+      result = char('A' + (idx % base)) + result;
+      idx = (idx / base) - 1;
+    }
+
+    return result;
+  }
+
+  void dumpImpl(llvm::raw_ostream &os, VPrinter &&vp, EPrinter &&ep) {
+    auto mappings = computeMappings();
+    outputNodes(os, mappings, std::forward<VPrinter>(vp));
+
+    for (auto eIt = graph->edgesBegin(); eIt != graph->edgesEnd(); eIt++) {
+
+      auto fromVertex = (*eIt).from;
+      auto toVertex = (*eIt).to;
+
+      const std::string &identifier = mappings.at(fromVertex);
+      const std::string &toIdentifier = mappings.at(toVertex);
+
+      os << identifier << " --> " << toIdentifier << "\n";
+    }
+  }
+
+  template <class VPrinterT>
+  void callVertexPrinter(VPrinterT &&vp, VertexProperty &prop,
+                         llvm::raw_ostream &os) {
+
+    if constexpr (!std::is_same_v<VPrinterT, std::nullptr_t>) {
+      os << "(\"";
+      std::forward<VPrinter>(vp)(prop, os);
+      os << "\")";
+    }
+  }
+
+  void outputNodes(llvm::raw_ostream &os,
+                   llvm::DenseMap<VertexDescriptor, std::string> &mappings,
+                   VPrinter &&vp) {
+    for (auto vIt = graph->verticesBegin(); vIt != graph->verticesEnd();
+         vIt++) {
+      std::string identifier = mappings.at(*vIt);
+      os << identifier;
+
+      VertexProperty &prop = (**(*vIt).value);
+      callVertexPrinter<VPrinter>(std::forward<VPrinter>(vp), prop, os);
+
+      os << "\n";
+    }
+  }
+
+  llvm::DenseMap<VertexDescriptor, std::string> computeMappings() {
+    llvm::DenseMap<VertexDescriptor, std::string> result;
+
+    int idx = 0;
+    for (auto vIt = graph->verticesBegin(); vIt != graph->verticesEnd();
+         vIt++) {
+      std::string identifier = indexToStringIdentifier(idx++);
+      result[*vIt] = identifier;
+    }
+
+    return result;
+  }
+
+private:
+  GraphType *graph;
+};
+} // namespace impl
+
+//==----------------------------------------------------------------------===//
+// GraphDumper
+//
+// This is the main type-erased object that handles forwarding the graph
+// and printers to the backend.
+//==----------------------------------------------------------------------===//
+template <template <class GraphType, class... Printers> class Backend =
+              impl::GraphDumperMermaidBackend>
+struct GraphDumper : public internal::Dumpable {
+  void dump(llvm::raw_ostream &os) const override { pimpl->dump(os); }
+
+  template <class GraphType, class... Printers>
+  GraphDumper(GraphType *graph, Printers &&...printers) {
+    using GraphWrapperImplType =
+        GraphWrapperImpl<GraphType, impl::PrinterWrapper<Printers>...>;
+
+    pimpl = std::make_unique<GraphWrapperImplType>(
+        graph,
+        impl::PrinterWrapper<Printers>(std::forward<Printers>(printers))...);
+  }
+
+  struct GraphWrapperInterface {
+    virtual ~GraphWrapperInterface() = default;
+    virtual void dump(llvm::raw_ostream &os) = 0;
+  };
+
+  template <class GraphType, class... Printers>
+  struct GraphWrapperImpl : public GraphWrapperInterface {
+    ~GraphWrapperImpl() final = default;
+
+    GraphWrapperImpl(GraphType *graph, Printers &&...printers)
+        : dumper{graph},
+          printers{std::make_tuple(std::forward<Printers>(printers)...)} {}
+
+    void dump(llvm::raw_ostream &os) final {
+      dumpImpl(os, std::index_sequence_for<Printers...>{});
+    }
+
+    template <std::size_t... Indices>
+    void dumpImpl(llvm::raw_ostream &os, std::index_sequence<Indices...>) {
+      dumper.dump(os, std::move(std::get<Indices>(printers))...);
+    }
+
+    Backend<GraphType, Printers...> dumper;
+    std::tuple<Printers...> printers;
+  };
+
+  std::unique_ptr<GraphWrapperInterface> pimpl;
+};
+
+template <
+    template <class, class...> class Backend = impl::GraphDumperMermaidBackend>
+GraphDumper() -> GraphDumper<Backend>;
+
+} // namespace marco::modeling::internal
+
+#endif // MARCO_MODELING_GRAPHDUMPER_H

--- a/unittest/Modeling/CMakeLists.txt
+++ b/unittest/Modeling/CMakeLists.txt
@@ -11,7 +11,9 @@ set(SOURCES
     PointTest.cpp
     RangeTest.cpp
     SolveLocalMatchingProblemTest.cpp
-    UndirectedGraphTest.cpp)
+    UndirectedGraphTest.cpp
+    GraphDumperTest.cpp
+)
 
 marco_add_unittest(ModelingTest ${SOURCES})
 

--- a/unittest/Modeling/GraphDumperTest.cpp
+++ b/unittest/Modeling/GraphDumperTest.cpp
@@ -1,0 +1,195 @@
+#include "marco/Modeling/GraphDumper.h"
+#include "marco/Modeling/Graph.h"
+#include "llvm/ADT/StringRef.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <llvm/Support/raw_ostream.h>
+#include <typeinfo>
+
+using namespace marco::modeling::internal;
+
+template <class GraphType, class VPrinter,
+          class EPrinter = impl::PrinterWrapper<std::nullptr_t>>
+class GraphDumperTestBackend {
+public:
+  using VertexDescriptor = typename GraphType::VertexDescriptor;
+  using EdgeDescriptor = typename GraphType::EdgeDescriptor;
+
+  using VertexProperty = typename GraphType::VertexProperty;
+  using EdgeProperty = typename GraphType::EdgeProperty;
+
+  void dump(llvm::raw_ostream &os, VPrinter &&vp, EPrinter &&ep = nullptr) {
+    dumpImpl(os, std::forward<VPrinter>(vp), std::forward<EPrinter>(ep));
+  }
+
+  void dumpImpl(llvm::raw_ostream &os, VPrinter &&vp, EPrinter &&ep) {
+    for (auto eIt = graph->edgesBegin(); eIt != graph->edgesEnd(); eIt++) {
+
+      auto edgeDescriptor = *eIt;
+
+      const auto fromVertexDescriptor = edgeDescriptor.from;
+      const auto toVertexDescriptor = edgeDescriptor.to;
+
+      const auto fromVertexWrapper = *fromVertexDescriptor.value;
+      const auto toVertexWrapper = *toVertexDescriptor.value;
+
+      const auto fromVertex = *(fromVertexWrapper);
+      const auto toVertex = *(toVertexWrapper);
+
+      vp(fromVertex, os);
+
+      if (ep.isValid()) {
+        ep(***edgeDescriptor.value, os);
+      } else {
+        os << " --> ";
+      }
+      vp(toVertex, os);
+      os << "\n";
+    }
+  }
+
+  GraphDumperTestBackend(GraphType *graph) : graph{graph} {}
+
+private:
+  GraphType *graph;
+};
+
+TEST(GraphDumper, dump_vprinter_only) {
+
+  DirectedGraph<char, int> graph{};
+
+  auto nodeA = graph.addVertex('a');
+  auto nodeB = graph.addVertex('b');
+  auto edgeAB = graph.addEdge(nodeA, nodeB, 2);
+
+  auto vprinter = [](char v, llvm::raw_ostream &os) { os << v; };
+
+  GraphDumper<GraphDumperTestBackend> dumper(&graph, vprinter);
+
+  std::string result;
+  llvm::raw_string_ostream resultOutputString{result};
+
+  dumper.dump(resultOutputString);
+
+  EXPECT_EQ(result, "a --> b\n");
+}
+
+TEST(GraphDumper, dump_both_printers) {
+
+  DirectedGraph<char, int> graph{};
+
+  auto nodeA = graph.addVertex('a');
+  auto nodeB = graph.addVertex('b');
+  auto _ = graph.addEdge(nodeA, nodeB, 2);
+
+  auto vprinter = [](char v, llvm::raw_ostream &os) { os << v; };
+
+  auto eprinter = [](int e, llvm::raw_ostream &os) { os << " (" << e << ") "; };
+
+  GraphDumper<GraphDumperTestBackend> dumper(&graph, vprinter, eprinter);
+
+  std::string result;
+  llvm::raw_string_ostream resultOutputString{result};
+
+  dumper.dump(resultOutputString);
+
+  EXPECT_EQ(result, "a (2) b\n");
+}
+
+//===------------------------------------------------------------===
+//=== Variadic GraphDumper Tests
+//===------------------------------------------------------------===
+
+template <class GraphType, class VPrinter, class EPrinter = std::nullptr_t,
+          class ComPrinter = std::nullptr_t>
+class GraphDumperTestBackendVariadic {
+public:
+  using VertexDescriptor = typename GraphType::VertexDescriptor;
+  using EdgeDescriptor = typename GraphType::EdgeDescriptor;
+
+  using VertexProperty = typename GraphType::VertexProperty;
+  using EdgeProperty = typename GraphType::EdgeProperty;
+
+  // void dump(llvm::raw_ostream &os, VPrinter &&vp, EPrinter &&ep, ComPrinter
+  // &&cp) const {
+  //   GraphDumperTestBackendVaridic dumper(graph);
+  //   dumper.dumpImpl(os, std::forward<VPrinter>(vp),
+  //   std::forward<EPrinter>(ep), std::forward<ComPrinter>(cp));
+  // }
+
+  // void dump(llvm::raw_ostream &os, VPrinter &&vp) const {
+  //   GraphDumperTestBackendVariadic dumper(graph);
+  //   dumper.dumpImpl(os, std::forward<VPrinter>(vp), nullptr);
+  // }
+
+  void dump(llvm::raw_ostream &os, VPrinter &&vp, EPrinter &&ep,
+            ComPrinter &&cp) const {
+    dumpImpl(os, std::forward<VPrinter>(vp), std::forward<EPrinter>(ep),
+             std::forward<ComPrinter>(cp));
+  }
+
+  void dumpImpl(llvm::raw_ostream &os, VPrinter &&vp, EPrinter &&ep,
+                ComPrinter &&cp) const {
+    for (auto eIt = graph->edgesBegin(); eIt != graph->edgesEnd(); eIt++) {
+
+      auto edgeDescriptor = *eIt;
+
+      const auto fromVertexDescriptor = edgeDescriptor.from;
+      const auto toVertexDescriptor = edgeDescriptor.to;
+
+      const auto fromVertexWrapper = *fromVertexDescriptor.value;
+      const auto toVertexWrapper = *toVertexDescriptor.value;
+
+      const auto fromVertex = *(fromVertexWrapper);
+      const auto toVertex = *(toVertexWrapper);
+
+      vp(fromVertex, os);
+
+      if (ep.isValid()) {
+        ep(***edgeDescriptor.value, os);
+      } else {
+        os << " --> ";
+      }
+      // if constexpr (!std::is_same_v<EPrinter, std::nullptr_t>) {
+      //   ep(***edgeDescriptor.value, os);
+      // } else {
+      //   os << " --> ";
+      // }
+      vp(toVertex, os);
+
+      if constexpr (!std::is_same_v<ComPrinter, std::nullptr_t>) {
+        cp(os);
+      }
+      os << "\n";
+    }
+  }
+
+  GraphDumperTestBackendVariadic(GraphType *graph) : graph{graph} {}
+
+private:
+  GraphType *graph;
+};
+
+TEST(GraphDumper, variadic) {
+  DirectedGraph<char, int> graph{};
+
+  auto nodeA = graph.addVertex('a');
+  auto nodeB = graph.addVertex('b');
+  auto _ = graph.addEdge(nodeA, nodeB, 2);
+
+  auto vprinter = [](char v, llvm::raw_ostream &os) { os << v; };
+
+  auto eprinter = [](int e, llvm::raw_ostream &os) { os << " (" << e << ") "; };
+
+  auto comprinter = [](llvm::raw_ostream &os) { os << " Comment"; };
+
+  GraphDumper<GraphDumperTestBackendVariadic> dumper(&graph, vprinter, eprinter,
+                                                     comprinter);
+
+  std::string result;
+  llvm::raw_string_ostream resultOutputString{result};
+
+  dumper.dump(resultOutputString);
+
+  EXPECT_EQ(result, "a (2) b Comment\n");
+}


### PR DESCRIPTION
Adds a work in progress, general Graph Dumper. 

On its own, it is up to the user to specify how vertices and edges are printed. By default, `GraphDumper` will default to the `GraphDumperMermaidBackend` backend.

**Usage:**
`GraphDumper` is a type-erased object that holds a wrapper object containing the pointer to the graph and the functors used to print vertices and edges.

The following example uses a functor (a lambda in this case) that takes in the graph's vertex property type as its first argument, and a reference to the output stream as its second.
```cpp
auto vertexPrinter = [](EquationWrapper &eq, llvm::raw_ostream &os) {
      bool first = true;
      for (Variable &write : eq.writes) {
        std::string res{};
        llvm::raw_string_ostream ss{res};
        write.indices.dump(ss);

        if (!first)
          os << ", ";
        first = false;
        os << write.name << " " << ss.str();
      }
    };
```

```cpp
using marco::modeling::internal::GraphDumper;
// graph is any kind of Graph from the modeling library
GraphDumper dumper{&graph, vertexPrinter, nullptr};
dumper.dump(llvm::outs());
```

Alternatively, with a different backend (only the Mermaid backend currently):
```cpp
using marco::modeling::internal::GraphDumper;
// graph is any kind of Graph from the modeling library
GraphDumper<MermaidBackend> dumper{&graph, vertexPrinter, nullptr};
dumper.dump(llvm::outs());
```

This template will successfully resolve as long as the backend itself is a template taking three template parameters: `GraphType`, and the `VertexPrinter` and `EdgePrinter` functor types.