### PR TITLE
Fix and improve matching algorithm

### DIFF
--- a/include/private/marco/Modeling/IndexSetImpl.h
+++ b/include/private/marco/Modeling/IndexSetImpl.h
@@ -100,6 +100,10 @@ public:
 
   virtual const_range_iterator rangesEnd() const = 0;
 
+  virtual int compare(const IndexSet::Impl &other) const = 0;
+
+  int compareGenericIndexSet(const IndexSet::Impl &other) const;
+
   virtual bool contains(const Point &other) const = 0;
 
   virtual bool contains(const MultidimensionalRange &other) const = 0;

--- a/include/private/marco/Modeling/IndexSetList.h
+++ b/include/private/marco/Modeling/IndexSetList.h
@@ -95,6 +95,10 @@ public:
 
   const_range_iterator rangesEnd() const override;
 
+  int compare(const IndexSet::Impl &other) const override;
+
+  int compare(const ListIndexSet &other) const;
+
   bool contains(const Point &other) const override;
 
   bool contains(const MultidimensionalRange &other) const override;

--- a/include/private/marco/Modeling/IndexSetRTree.h
+++ b/include/private/marco/Modeling/IndexSetRTree.h
@@ -148,6 +148,10 @@ public:
 
   const_range_iterator rangesEnd() const override;
 
+  int compare(const IndexSet::Impl &other) const override;
+
+  int compare(const RTreeIndexSet &other) const;
+
   bool contains(const Point &other) const override;
 
   bool contains(const MultidimensionalRange &other) const override;

--- a/include/private/marco/Modeling/LocalMatchingSolutionsMCIM.h
+++ b/include/private/marco/Modeling/LocalMatchingSolutionsMCIM.h
@@ -18,6 +18,15 @@ public:
 private:
   void compute(const MCIM &obj);
 
+  /// @name Debug methods.
+  /// {
+
+  /// Check if the computed solutions cover all the indices that are set inside
+  /// the original matrix.
+  [[maybe_unused]] bool allIndicesCovered(const MCIM &obj) const;
+
+  /// }
+
   llvm::SmallVector<MCIM, 3> solutions;
 };
 } // namespace marco::modeling::internal

--- a/include/public/marco/Dialect/BaseModelica/Transforms/Modeling/VariableBridge.h
+++ b/include/public/marco/Dialect/BaseModelica/Transforms/Modeling/VariableBridge.h
@@ -44,6 +44,9 @@ public:
   VariableBridge &operator=(const VariableBridge &other) = delete;
   VariableBridge &operator==(const VariableBridge &other) = delete;
 };
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const VariableBridge::Id &obj);
 } // namespace mlir::bmodelica::bridge
 
 namespace llvm {

--- a/include/public/marco/Modeling/IndexSet.h
+++ b/include/public/marco/Modeling/IndexSet.h
@@ -168,6 +168,8 @@ public:
 
   const_range_iterator rangesEnd() const;
 
+  int compare(const IndexSet &other) const;
+
   bool contains(const Point &other) const;
 
   bool contains(const MultidimensionalRange &other) const;

--- a/include/public/marco/Modeling/Matching.h
+++ b/include/public/marco/Modeling/Matching.h
@@ -8,6 +8,7 @@
 #include "marco/Modeling/AccessFunction.h"
 #include "marco/Modeling/Dumpable.h"
 #include "marco/Modeling/Graph.h"
+#include "marco/Modeling/GraphDumper.h"
 #include "marco/Modeling/LocalMatchingSolutions.h"
 #include "marco/Modeling/MCIM.h"
 #include "marco/Modeling/Range.h"
@@ -720,7 +721,7 @@ public:
   void dump(llvm::raw_ostream &os) const override {
     os << "--------------------------------------------------\n";
     os << "Matching graph\n";
-    os << "- Vertices:\n";
+    os << "- Nodes:\n";
 
     for (auto vertexDescriptor :
          llvm::make_range(graph.verticesBegin(), graph.verticesEnd())) {
@@ -731,13 +732,21 @@ public:
       os << "\n";
     }
 
-    os << "- Equations:\n";
-
     for (auto equationDescriptor :
          llvm::make_range(graph.edgesBegin(), graph.edgesEnd())) {
       graph[equationDescriptor].dump(os);
       os << "\n";
     }
+
+    os << "- Visualization:\n";
+
+    auto vertexPrinter = [](const Vertex &vertex, llvm::raw_ostream &os) {
+      std::visit([&](const auto &wrapper) { os << wrapper.getId(); }, vertex);
+    };
+
+    internal::GraphDumper graphDumper(&graph, vertexPrinter);
+    graphDumper.dump(os);
+    os << "\n";
 
     os << "--------------------------------------------------\n";
   }

--- a/include/public/marco/Modeling/MultidimensionalRange.h
+++ b/include/public/marco/Modeling/MultidimensionalRange.h
@@ -76,6 +76,8 @@ public:
 
   unsigned int flatSize() const;
 
+  int compare(const MultidimensionalRange &other) const;
+
   bool contains(const Point &other) const;
 
   bool contains(const MultidimensionalRange &other) const;

--- a/include/public/marco/Modeling/Range.h
+++ b/include/public/marco/Modeling/Range.h
@@ -64,6 +64,8 @@ public:
 
   size_t size() const;
 
+  int compare(const Range &other) const;
+
   /// Check if the range contains a point.
   bool contains(data_type value) const;
 

--- a/lib/Dialect/BaseModelica/Transforms/Modeling/VariableBridge.cpp
+++ b/lib/Dialect/BaseModelica/Transforms/Modeling/VariableBridge.cpp
@@ -63,6 +63,11 @@ std::unique_ptr<VariableBridge> VariableBridge::build(VariableOp variable) {
 VariableBridge::VariableBridge(mlir::SymbolRefAttr name,
                                marco::modeling::IndexSet indices)
     : id(name), name(name), indices(std::move(indices)) {}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const VariableBridge::Id &obj) {
+  return os << obj.name;
+}
 } // namespace mlir::bmodelica::bridge
 
 namespace marco::modeling::matching {

--- a/lib/Modeling/IndexSetList.cpp
+++ b/lib/Modeling/IndexSetList.cpp
@@ -609,6 +609,21 @@ ListIndexSet::const_range_iterator ListIndexSet::rangesEnd() const {
   return ListIndexSet::RangeIterator::end(*this);
 }
 
+int ListIndexSet::compare(const IndexSet::Impl &other) const {
+  if (auto *otherCasted = other.dyn_cast<ListIndexSet>()) {
+    int optimizedResult = compare(*otherCasted);
+    assert(optimizedResult == compareGenericIndexSet(other));
+    return optimizedResult;
+  }
+
+  return compareGenericIndexSet(other);
+}
+
+int ListIndexSet::compare(const ListIndexSet &other) const {
+  // TODO Implement optimized comparison
+  return compareGenericIndexSet(other);
+}
+
 bool ListIndexSet::contains(const Point &other) const {
   return llvm::any_of(ranges, [&](const MultidimensionalRange &range) {
     return range.contains(other);

--- a/lib/Modeling/IndexSetRTree.cpp
+++ b/lib/Modeling/IndexSetRTree.cpp
@@ -911,6 +911,21 @@ RTreeIndexSet::const_range_iterator RTreeIndexSet::rangesEnd() const {
   return RTreeIndexSet::RangeIterator::end(*this);
 }
 
+int RTreeIndexSet::compare(const IndexSet::Impl &other) const {
+  if (auto *otherCasted = other.dyn_cast<RTreeIndexSet>()) {
+    int optimizedResult = compare(*otherCasted);
+    assert(optimizedResult == compareGenericIndexSet(other));
+    return optimizedResult;
+  }
+
+  return compareGenericIndexSet(other);
+}
+
+int RTreeIndexSet::compare(const RTreeIndexSet &other) const {
+  // TODO Implement optimized comparison
+  return compareGenericIndexSet(other);
+}
+
 bool RTreeIndexSet::contains(const Point &other) const {
   return contains(MultidimensionalRange(other));
 }

--- a/lib/Modeling/LocalMatchingSolutionsMCIM.cpp
+++ b/lib/Modeling/LocalMatchingSolutionsMCIM.cpp
@@ -17,5 +17,26 @@ void MCIMSolutions::compute(const MCIM &obj) {
 
     solutions.push_back(std::move(solution));
   }
+
+  assert(allIndicesCovered(obj) &&
+         "The computed local matching solutions discard some indices");
+}
+
+bool MCIMSolutions::allIndicesCovered(const MCIM &obj) const {
+  for (auto coordinates :
+       llvm::make_range(obj.indicesBegin(), obj.indicesEnd())) {
+    Point equation = coordinates.first;
+    Point variable = coordinates.second;
+
+    if (obj.get(equation, variable)) {
+      if (!llvm::any_of(solutions, [&](const MCIM &solution) {
+            return solution.get(equation, variable);
+          })) {
+        return false;
+      }
+    }
+  }
+
+  return true;
 }
 } // namespace marco::modeling::internal

--- a/lib/Modeling/MCIM.cpp
+++ b/lib/Modeling/MCIM.cpp
@@ -207,6 +207,24 @@ MCIM &MCIM::operator-=(const MCIM &rhs) {
 
   for (auto &group : oldGroups) {
     if (!group->empty()) {
+      // Remove the keys that overlap with the extra points.
+      for (const MultidimensionalRange &range :
+           llvm::make_range(rhs.points.rangesBegin(), rhs.points.rangesEnd())) {
+        MultidimensionalRange equations =
+            range.takeFirstDimensions(rhs.equationRanges.rank());
+
+        MultidimensionalRange variables =
+            range.takeLastDimensions(rhs.variableRanges.rank());
+
+        IndexSet inverseKeys = group->getAccessFunction().inverseMap(
+            IndexSet(variables), group->getKeys());
+
+        IndexSet keysIntersection = inverseKeys.intersect(equations);
+        group->removeKeys(keysIntersection);
+      }
+    }
+
+    if (!group->empty()) {
       addGroup(std::move(group));
     }
   }

--- a/lib/Modeling/MCIM.cpp
+++ b/lib/Modeling/MCIM.cpp
@@ -181,6 +181,16 @@ MCIM &MCIM::operator+=(const MCIM &rhs) {
     set(equation, variable);
   }
 
+  assert(std::all_of(rhs.indicesBegin(), rhs.indicesEnd(),
+                     [&](std::pair<Point, Point> coordinates) {
+                       if (rhs.get(coordinates.first, coordinates.second)) {
+                         return get(coordinates.first, coordinates.second);
+                       }
+
+                       return true;
+                     }) &&
+         "Not all points were correctly added");
+
   return *this;
 }
 
@@ -230,6 +240,17 @@ MCIM &MCIM::operator-=(const MCIM &rhs) {
   }
 
   points -= rhs.points;
+
+  assert(std::all_of(rhs.indicesBegin(), rhs.indicesEnd(),
+                     [&](std::pair<Point, Point> coordinates) {
+                       if (rhs.get(coordinates.first, coordinates.second)) {
+                         return !get(coordinates.first, coordinates.second);
+                       }
+
+                       return true;
+                     }) &&
+         "Not all points were correctly removed");
+
   return *this;
 }
 

--- a/lib/Modeling/MCIM.cpp
+++ b/lib/Modeling/MCIM.cpp
@@ -441,6 +441,7 @@ std::vector<MCIM> MCIM::splitGroups() const {
     Point equation = point.takeFront(equationRanges.rank());
     Point variable = point.takeBack(variableRanges.rank());
     group.set(equation, variable);
+    result.push_back(std::move(group));
   }
 
   return result;

--- a/lib/Modeling/MultidimensionalRange.cpp
+++ b/lib/Modeling/MultidimensionalRange.cpp
@@ -57,48 +57,12 @@ bool MultidimensionalRange::operator!=(
 
 bool MultidimensionalRange::operator<(
     const MultidimensionalRange &other) const {
-  if (rank() < other.rank()) {
-    return true;
-  }
-
-  if (rank() > other.rank()) {
-    return false;
-  }
-
-  for (size_t i = 0, e = rank(); i < e; ++i) {
-    if (ranges[i] < other.ranges[i]) {
-      return true;
-    }
-
-    if (ranges[i] > other.ranges[i]) {
-      return false;
-    }
-  }
-
-  return false;
+  return compare(other) < 0;
 }
 
 bool MultidimensionalRange::operator>(
     const MultidimensionalRange &other) const {
-  if (rank() > other.rank()) {
-    return true;
-  }
-
-  if (rank() < other.rank()) {
-    return false;
-  }
-
-  for (size_t i = 0, e = rank(); i < e; ++i) {
-    if (ranges[i] > other.ranges[i]) {
-      return true;
-    }
-
-    if (ranges[i] < other.ranges[i]) {
-      return false;
-    }
-  }
-
-  return false;
+  return compare(other) > 0;
 }
 
 Range &MultidimensionalRange::operator[](size_t index) {
@@ -128,6 +92,23 @@ unsigned int MultidimensionalRange::flatSize() const {
   }
 
   return result;
+}
+
+int MultidimensionalRange::compare(const MultidimensionalRange &other) const {
+  unsigned int rank1 = rank();
+  unsigned int rank2 = other.rank();
+
+  if (rank1 != rank2) {
+    return rank1 < rank2 ? -1 : 1;
+  }
+
+  for (unsigned int i = 0; i < rank1; ++i) {
+    if (auto rangeCmp = ranges[i].compare(other.ranges[i]); rangeCmp != 0) {
+      return rangeCmp;
+    }
+  }
+
+  return 0;
 }
 
 bool MultidimensionalRange::contains(const Point &other) const {

--- a/lib/Modeling/Range.cpp
+++ b/lib/Modeling/Range.cpp
@@ -49,6 +49,26 @@ Range::data_type Range::getEnd() const { return end_; }
 
 size_t Range::size() const { return getEnd() - getBegin(); }
 
+int Range::compare(const Range &other) const {
+  if (getBegin() == other.getBegin()) {
+    if (getEnd() == other.getEnd()) {
+      return 0;
+    }
+
+    if (getEnd() < other.getEnd()) {
+      return -1;
+    }
+
+    return 1;
+  }
+
+  if (getBegin() < other.getBegin()) {
+    return -1;
+  }
+
+  return 1;
+}
+
 bool Range::contains(Range::data_type value) const {
   return value >= getBegin() && value < getEnd();
 }

--- a/unittest/Modeling/MultidimensionalRangeTest.cpp
+++ b/unittest/Modeling/MultidimensionalRangeTest.cpp
@@ -16,6 +16,23 @@ TEST(MultidimensionalRange, flatSize) {
   EXPECT_EQ(range.flatSize(), 18);
 }
 
+TEST(MultidimensionalRange, compare) {
+  MultidimensionalRange r1({Range(0, 10), Range(2, 5)});
+  MultidimensionalRange r2({Range(0, 10), Range(3, 7)});
+  MultidimensionalRange r3({Range(5, 10), Range(2, 5)});
+  MultidimensionalRange r4({Range(0, 10), Range(2, 5), Range(3, 7)});
+
+  EXPECT_EQ(r1.compare(r1), 0);
+
+  EXPECT_LT(r1.compare(r2), 0);
+  EXPECT_LT(r1.compare(r3), 0);
+  EXPECT_LT(r1.compare(r4), 0);
+
+  EXPECT_GT(r2.compare(r1), 0);
+  EXPECT_GT(r3.compare(r1), 0);
+  EXPECT_GT(r4.compare(r1), 0);
+}
+
 TEST(MultidimensionalRange, iteration) {
   MultidimensionalRange range({Range(1, 3), Range(2, 5), Range(8, 10)});
 

--- a/unittest/Modeling/RangeTest.cpp
+++ b/unittest/Modeling/RangeTest.cpp
@@ -16,6 +16,23 @@ TEST(Range, size) {
   EXPECT_EQ(range.size(), 4);
 }
 
+TEST(Range, compare) {
+  Range r1(0, 10);
+  Range r2(0, 20);
+  Range r3(1, 10);
+  Range r4(1, 20);
+
+  EXPECT_EQ(r1.compare(r1), 0);
+
+  EXPECT_LT(r1.compare(r2), 0);
+  EXPECT_LT(r1.compare(r3), 0);
+  EXPECT_LT(r1.compare(r4), 0);
+
+  EXPECT_GT(r4.compare(r1), 0);
+  EXPECT_GT(r4.compare(r2), 0);
+  EXPECT_GT(r4.compare(r3), 0);
+}
+
 TEST(Range, iteration) {
   Range range(1, 5);
 


### PR DESCRIPTION
This pull request addresses several problems related to the matching algorithm:
- The computation of local matching solutions for a MCIM was not considering the spare indices.
- The subtraction between two MCIMs did not consider the case of spare indices overlapping with the key and values associated to the access function.
- The discovery of augmenting paths was not avoiding already visited nodes, thus possibly ending in an infinite growth.
- The heuristic used for ordering the augmenting paths was nondeterministic, in case of paths having the same flow size, due to the nature of the sort method.