### PR TITLE
Add edge printer and simple unit tests to Mermaid Backend

### DIFF
--- a/unittest/Modeling/CMakeLists.txt
+++ b/unittest/Modeling/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES
     SolveLocalMatchingProblemTest.cpp
     UndirectedGraphTest.cpp
     GraphDumperTest.cpp
+    GraphDumperMermaidBackendTest.cpp
 )
 
 marco_add_unittest(ModelingTest ${SOURCES})

--- a/unittest/Modeling/GraphDumperMermaidBackendTest.cpp
+++ b/unittest/Modeling/GraphDumperMermaidBackendTest.cpp
@@ -1,0 +1,51 @@
+#include "marco/Modeling/Graph.h"
+#include "marco/Modeling/GraphDumper.h"
+#include "llvm/ADT/StringRef.h"
+#include "gtest/gtest.h"
+#include <llvm/Support/raw_ostream.h>
+#include <typeinfo>
+
+using namespace marco::modeling::internal;
+
+TEST(GraphDumperMermaidBackend, dump_vprinter_only) {
+
+  DirectedGraph<char, int> graph{};
+
+  auto nodeA = graph.addVertex('a');
+  auto nodeB = graph.addVertex('b');
+  auto edgeAB = graph.addEdge(nodeA, nodeB, 2);
+
+  auto vprinter = [](char v, llvm::raw_ostream &os) { os << v; };
+
+  GraphDumper<impl::GraphDumperMermaidBackend> dumper(&graph, vprinter);
+
+  std::string result;
+  llvm::raw_string_ostream resultOutputString{result};
+
+  dumper.dump(resultOutputString);
+
+  EXPECT_EQ(result, "A(\"a\")\nB(\"b\")\nA --> B\n");
+}
+
+TEST(GraphDumperMermaidBackend, dump_vprinter_eprinter) {
+
+  DirectedGraph<char, int> graph{};
+
+  auto nodeA = graph.addVertex('a');
+  auto nodeB = graph.addVertex('b');
+  auto edgeAB = graph.addEdge(nodeA, nodeB, 2);
+
+  auto vprinter = [](char v, llvm::raw_ostream &os) { os << v; };
+
+  auto eprinter = [](int i, llvm::raw_ostream &os) { os << i; };
+
+  GraphDumper<impl::GraphDumperMermaidBackend> dumper(&graph, vprinter,
+                                                      eprinter);
+
+  std::string result;
+  llvm::raw_string_ostream resultOutputString{result};
+
+  dumper.dump(resultOutputString);
+
+  EXPECT_EQ(result, "A(\"a\")\nB(\"b\")\nA --\"2\"--> B\n");
+}


### PR DESCRIPTION
This PR refines the Mermaid Backend for `GraphDumper` and adds edge printers.

Also adds deduction guides for the `PrinterWrapper`, so the backend can forward a defaulted no-op printer when, e.g., the edge printer was not supplied.