### PR TITLE
Split one-sized ranges into separate equation instances

### DIFF
--- a/include/public/marco/Dialect/BaseModelica/Transforms/Passes.h
+++ b/include/public/marco/Dialect/BaseModelica/Transforms/Passes.h
@@ -38,6 +38,7 @@
 #include "marco/Dialect/BaseModelica/Transforms/SCCDetection.h"
 #include "marco/Dialect/BaseModelica/Transforms/SCCSolvingBySubstitution.h"
 #include "marco/Dialect/BaseModelica/Transforms/SCCSolvingWithKINSOL.h"
+#include "marco/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit.h"
 #include "marco/Dialect/BaseModelica/Transforms/ScheduleParallelization.h"
 #include "marco/Dialect/BaseModelica/Transforms/SchedulersInstantiation.h"
 #include "marco/Dialect/BaseModelica/Transforms/Scheduling.h"

--- a/include/public/marco/Dialect/BaseModelica/Transforms/Passes.td
+++ b/include/public/marco/Dialect/BaseModelica/Transforms/Passes.td
@@ -350,6 +350,17 @@ def ReadOnlyVariablesPropagationPass
     let constructor = "mlir::bmodelica::createReadOnlyVariablesPropagationPass()";
 }
 
+def ScalarRangesEquationSplitPass
+    : Pass<"scalar-ranges-equation-split", "mlir::ModuleOp">
+{
+    let dependentDialects = [
+        "mlir::bmodelica::BaseModelicaDialect"
+    ];
+
+    let constructor =
+        "mlir::bmodelica::createScalarRangesEquationSplitPass()";
+}
+
 def ScheduleParallelizationPass
     : Pass<"schedule-parallelization", "mlir::ModuleOp">
 {

--- a/include/public/marco/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit.h
+++ b/include/public/marco/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit.h
@@ -1,0 +1,13 @@
+#ifndef MARCO_DIALECT_BASEMODELICA_TRANSFORMS_SCALARRANGESEQUATIONSPLIT_H
+#define MARCO_DIALECT_BASEMODELICA_TRANSFORMS_SCALARRANGESEQUATIONSPLIT_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::bmodelica {
+#define GEN_PASS_DECL_SCALARRANGESEQUATIONSPLITPASS
+#include "marco/Dialect/BaseModelica/Transforms/Passes.h.inc"
+
+std::unique_ptr<mlir::Pass> createScalarRangesEquationSplitPass();
+} // namespace mlir::bmodelica
+
+#endif // MARCO_DIALECT_BASEMODELICA_TRANSFORMS_SCALARRANGESEQUATIONSPLIT_H

--- a/lib/Dialect/BaseModelica/Transforms/CMakeLists.txt
+++ b/lib/Dialect/BaseModelica/Transforms/CMakeLists.txt
@@ -48,6 +48,7 @@ add_mlir_dialect_library(MLIRBaseModelicaTransforms
     RecordInlining.cpp
     RungeKutta.cpp
     RuntimeVerifiableOpInterfaceImpl.cpp
+    ScalarRangesEquationSplit.cpp
     SCCAbsenceVerification.cpp
     SCCDetection.cpp
     SCCSolvingBySubstitution.cpp

--- a/lib/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit.cpp
+++ b/lib/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit.cpp
@@ -1,0 +1,111 @@
+#include "marco/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit.h"
+#include "marco/Dialect/BaseModelica/IR/BaseModelica.h"
+
+namespace mlir::bmodelica {
+#define GEN_PASS_DEF_SCALARRANGESEQUATIONSPLITPASS
+#include "marco/Dialect/BaseModelica/Transforms/Passes.h.inc"
+} // namespace mlir::bmodelica
+
+using namespace ::mlir::bmodelica;
+
+namespace {
+class ScalarRangesEquationSplitPass
+    : public impl::ScalarRangesEquationSplitPassBase<
+          ScalarRangesEquationSplitPass> {
+public:
+  using ScalarRangesEquationSplitPassBase<
+      ScalarRangesEquationSplitPass>::ScalarRangesEquationSplitPassBase;
+
+  void runOnOperation() override;
+
+private:
+  mlir::LogicalResult processModelOp(ModelOp modelOp);
+};
+} // namespace
+
+namespace {
+mlir::LogicalResult splitEquation(EquationInstanceOp equationOp,
+                                  mlir::SymbolTableCollection &symbolTables) {
+  mlir::IRRewriter rewriter(equationOp);
+  const IndexSet &indices = equationOp.getProperties().indices;
+
+  if (indices.empty()) {
+    // Nothing to do in case of scalar equation.
+    return mlir::success();
+  }
+
+  llvm::SmallVector<MultidimensionalRange> remaining;
+  bool modified = false;
+
+  for (const MultidimensionalRange &range :
+       llvm::make_range(indices.rangesBegin(), indices.rangesEnd())) {
+    if (range.flatSize() == 1) {
+      auto clonedOp = mlir::cast<EquationInstanceOp>(
+          rewriter.clone(*equationOp.getOperation()));
+
+      if (mlir::failed(clonedOp.setIndices(IndexSet(range), symbolTables))) {
+        return mlir::failure();
+      }
+
+      modified = true;
+    } else {
+      remaining.push_back(range);
+    }
+  }
+
+  if (modified) {
+    if (remaining.empty()) {
+      rewriter.eraseOp(equationOp);
+    } else {
+      if (mlir::failed(
+              equationOp.setIndices(IndexSet(remaining), symbolTables))) {
+        return mlir::failure();
+      }
+    }
+  }
+
+  return mlir::success();
+}
+} // namespace
+
+void ScalarRangesEquationSplitPass::runOnOperation() {
+  llvm::SmallVector<ModelOp, 1> modelOps;
+
+  walkClasses(getOperation(), [&](mlir::Operation *op) {
+    if (auto modelOp = mlir::dyn_cast<ModelOp>(op)) {
+      modelOps.push_back(modelOp);
+    }
+  });
+
+  if (mlir::failed(mlir::failableParallelForEach(
+          &getContext(), modelOps, [&](mlir::Operation *op) {
+            return processModelOp(mlir::cast<ModelOp>(op));
+          }))) {
+    return signalPassFailure();
+  }
+}
+
+mlir::LogicalResult
+ScalarRangesEquationSplitPass::processModelOp(ModelOp modelOp) {
+  llvm::SmallVector<EquationInstanceOp> equationOps;
+
+  modelOp.walk([&](EquationInstanceOp equationOp) {
+    equationOps.push_back(equationOp);
+  });
+
+  mlir::SymbolTableCollection symbolTables;
+
+  for (EquationInstanceOp equationOp : equationOps) {
+    if (mlir::failed(splitEquation(equationOp, symbolTables))) {
+      return mlir::failure();
+    }
+  }
+
+  return mlir::success();
+}
+
+namespace mlir::bmodelica {
+std::unique_ptr<mlir::Pass> createScalarRangesEquationSplitPass() {
+  return std::make_unique<ScalarRangesEquationSplitPass>();
+}
+} // namespace mlir::bmodelica

--- a/lib/Frontend/FrontendActions.cpp
+++ b/lib/Frontend/FrontendActions.cpp
@@ -925,6 +925,7 @@ void CodeGenAction::buildMLIRModelSolvingPipeline(mlir::PassManager &pm) {
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(createMLIRMatchingPass());
   pm.addPass(mlir::bmodelica::createEquationAccessSplitPass());
+  pm.addPass(mlir::bmodelica::createScalarRangesEquationSplitPass());
 
   if (ci.getCodeGenOptions().singleValuedInductionElimination) {
     pm.addPass(mlir::bmodelica::createSingleValuedInductionEliminationPass());

--- a/test/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit/matched-equation.mlir
+++ b/test/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit/matched-equation.mlir
@@ -1,0 +1,72 @@
+// RUN: modelica-opt %s --split-input-file --mlir-disable-threading --scalar-ranges-equation-split | FileCheck %s
+
+// CHECK-LABEL: @ScalarRanges
+
+bmodelica.model @ScalarRanges {
+    bmodelica.variable @x : !bmodelica.variable<10xf64>
+    
+    %t0 = bmodelica.equation_template inductions = [%i0] {
+        %0 = bmodelica.variable_get @x : tensor<10xf64>
+        %1 = bmodelica.tensor_extract %0[%i0] : tensor<10xf64>
+        %2 = bmodelica.constant 0.0 : f64
+        %3 = bmodelica.equation_side %1 : tuple<f64>
+        %4 = bmodelica.equation_side %2 : tuple<f64>
+        bmodelica.equation_sides %3, %4 : tuple<f64>, tuple<f64>
+    }
+
+    bmodelica.dynamic {
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[0,0]}, match = <@x, {[0,0]}>
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[2,2]}, match = <@x, {[2,2]}>
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[4,4]}, match = <@x, {[4,4]}>
+        // CHECK-NOT: bmodelica.equation_instance
+        bmodelica.equation_instance %t0, indices = {[0,0],[2,2],[4,4]}, match = <@x, {[0,0],[2,2],[4,4]}>
+    }
+}
+
+// -----
+
+// CHECK-LABEL: @NonScalarRanges
+
+bmodelica.model @NonScalarRanges {
+    bmodelica.variable @x : !bmodelica.variable<10xf64>
+
+    %t0 = bmodelica.equation_template inductions = [%i0] {
+        %0 = bmodelica.variable_get @x : tensor<10xf64>
+        %1 = bmodelica.tensor_extract %0[%i0] : tensor<10xf64>
+        %2 = bmodelica.constant 0.0 : f64
+        %3 = bmodelica.equation_side %1 : tuple<f64>
+        %4 = bmodelica.equation_side %2 : tuple<f64>
+        bmodelica.equation_sides %3, %4 : tuple<f64>, tuple<f64>
+    }
+
+    bmodelica.dynamic {
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[0,1],[3,4]}, match = <@x, {[0,1],[3,4]}>
+        // CHECK-NOT: bmodelica.equation_instance
+        bmodelica.equation_instance %t0, indices = {[0,1],[3,4]}, match = <@x, {[0,1],[3,4]}>
+    }
+}
+
+// -----
+
+// CHECK-LABEL: @MixedScalarAndNonScalarRanges
+
+bmodelica.model @MixedScalarAndNonScalarRanges {
+    bmodelica.variable @x : !bmodelica.variable<10xf64>
+
+    %t0 = bmodelica.equation_template inductions = [%i0] {
+        %0 = bmodelica.variable_get @x : tensor<10xf64>
+        %1 = bmodelica.tensor_extract %0[%i0] : tensor<10xf64>
+        %2 = bmodelica.constant 0.0 : f64
+        %3 = bmodelica.equation_side %1 : tuple<f64>
+        %4 = bmodelica.equation_side %2 : tuple<f64>
+        bmodelica.equation_sides %3, %4 : tuple<f64>, tuple<f64>
+    }
+
+    bmodelica.dynamic {
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[0,0]}, match = <@x, {[0,0]}>
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[2,2]}, match = <@x, {[2,2]}>
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[4,5],[7,8]}, match = <@x, {[4,5],[7,8]}>
+        // CHECK-NOT: bmodelica.equation_instance
+        bmodelica.equation_instance %t0, indices = {[0,0],[2,2],[4,5],[7,8]}, match = <@x, {[0,0],[2,2],[4,5],[7,8]}>
+    }
+}

--- a/test/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit/mixed.mlir
+++ b/test/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit/mixed.mlir
@@ -1,0 +1,20 @@
+// RUN: modelica-opt %s --split-input-file --mlir-disable-threading --scalar-ranges-equation-split | FileCheck %s
+
+// CHECK-LABEL: @Test
+
+bmodelica.model @Test {
+    %t0 = bmodelica.equation_template inductions = [%i0] {
+        %0 = bmodelica.constant 0.0 : f64
+        %1 = bmodelica.equation_side %0 : tuple<f64>
+        %2 = bmodelica.equation_side %0 : tuple<f64>
+        bmodelica.equation_sides %1, %2 : tuple<f64>, tuple<f64>
+    }
+
+    bmodelica.dynamic {
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[0,0]}
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[2,2]}
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[4,5],[7,8]}
+        // CHECK-NOT: bmodelica.equation_instance
+        bmodelica.equation_instance %t0, indices = {[0,0],[2,2],[4,5],[7,8]}
+    }
+}

--- a/test/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit/non-scalar-ranges.mlir
+++ b/test/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit/non-scalar-ranges.mlir
@@ -1,0 +1,18 @@
+// RUN: modelica-opt %s --split-input-file --mlir-disable-threading --scalar-ranges-equation-split | FileCheck %s
+
+// CHECK-LABEL: @Test
+
+bmodelica.model @Test {
+    %t0 = bmodelica.equation_template inductions = [%i0] {
+        %0 = bmodelica.constant 0.0 : f64
+        %1 = bmodelica.equation_side %0 : tuple<f64>
+        %2 = bmodelica.equation_side %0 : tuple<f64>
+        bmodelica.equation_sides %1, %2 : tuple<f64>, tuple<f64>
+    }
+
+    bmodelica.dynamic {
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[0,1],[3,4]}
+        // CHECK-NOT: bmodelica.equation_instance
+        bmodelica.equation_instance %t0, indices = {[0,1],[3,4]}
+    }
+}

--- a/test/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit/scalar-ranges.mlir
+++ b/test/Dialect/BaseModelica/Transforms/ScalarRangesEquationSplit/scalar-ranges.mlir
@@ -1,0 +1,41 @@
+// RUN: modelica-opt %s --split-input-file --mlir-disable-threading --scalar-ranges-equation-split | FileCheck %s
+
+// CHECK-LABEL: @Rank1
+
+bmodelica.model @Rank1 {
+    %t0 = bmodelica.equation_template inductions = [%i0] {
+        %0 = bmodelica.constant 0.0 : f64
+        %1 = bmodelica.equation_side %0 : tuple<f64>
+        %2 = bmodelica.equation_side %0 : tuple<f64>
+        bmodelica.equation_sides %1, %2 : tuple<f64>, tuple<f64>
+    }
+
+    bmodelica.dynamic {
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[0,0]}
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[2,2]}
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[4,4]}
+        // CHECK-NOT: bmodelica.equation_instance
+        bmodelica.equation_instance %t0, indices = {[0,0],[2,2],[4,4]}
+    }
+}
+
+// -----
+
+// CHECK-LABEL: @Rank2
+
+bmodelica.model @Rank2 {
+    %t0 = bmodelica.equation_template inductions = [%i0, %i1] {
+        %0 = bmodelica.constant 0.0 : f64
+        %1 = bmodelica.equation_side %0 : tuple<f64>
+        %2 = bmodelica.equation_side %0 : tuple<f64>
+        bmodelica.equation_sides %1, %2 : tuple<f64>, tuple<f64>
+    }
+
+    bmodelica.dynamic {
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[0,0][1,1]}
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[2,2][2,2]}
+        // CHECK-DAG: bmodelica.equation_instance %{{.*}} indices = {[3,3][4,4]}
+        // CHECK-NOT: bmodelica.equation_instance
+        bmodelica.equation_instance %t0, indices = {[0,0][1,1],[2,2][2,2],[3,3][4,4]}
+    }
+}


### PR DESCRIPTION
This PR introduces a pass that splits an equation instance into multiple instances according to the scalar ranges (i.e., the ranges having just one element) that compose its set of indices.
For example, the equation

```mlir
bmodelica.equation_instance %t0, indices = {[1,1],[3,3],[5,7]}
```

would be split into the three following instances

```mlir
bmodelica.equation_instance %t0, indices = {[1,1]}
bmodelica.equation_instance %t0, indices = {[3,3]}
bmodelica.equation_instance %t0, indices = {[5,7]}
```

This transformation reduces the time that the following passes have to spend in comparing index sets.