### PR TITLE
Fix conversion of DivOp

### DIFF
--- a/lib/Dialect/BaseModelica/Transforms/SCCSolvingBySubstitution.cpp
+++ b/lib/Dialect/BaseModelica/Transforms/SCCSolvingBySubstitution.cpp
@@ -17,8 +17,6 @@ namespace mlir::bmodelica {
 using namespace ::mlir::bmodelica;
 using namespace ::mlir::bmodelica::bridge;
 
-// #define LLVM_DEBUG(x) x;
-
 namespace {
 struct CyclicEquation {
   EquationInstanceOp equation;

--- a/test/Codegen/Conversion/BaseModelicaToArith/div.mlir
+++ b/test/Codegen/Conversion/BaseModelicaToArith/div.mlir
@@ -62,6 +62,23 @@ func.func @RealInteger(%arg0 : !bmodelica.real, %arg1 : !bmodelica.int) -> !bmod
 
 // -----
 
+// CHECK-LABEL: @IntegerOperandsAndRealResult
+// CHECK-SAME: (%[[arg0:.*]]: !bmodelica.int, %[[arg1:.*]]: !bmodelica.int) -> !bmodelica.real
+// CHECK-DAG: %[[arg0_casted:.*]] = builtin.unrealized_conversion_cast %[[arg0]] : !bmodelica.int to i64
+// CHECK-DAG: %[[arg1_casted:.*]] = builtin.unrealized_conversion_cast %[[arg1]] : !bmodelica.int to i64
+// CHECK-DAG: %[[lhs:.*]] = arith.sitofp %[[arg0_casted]] : i64 to f64
+// CHECK-DAG: %[[rhs:.*]] = arith.sitofp %[[arg1_casted]] : i64 to f64
+// CHECK: %[[result:.*]] = arith.divf %[[lhs]], %[[rhs]] : f64
+// CHECK: %[[result_casted:.*]] =  builtin.unrealized_conversion_cast %[[result]] : f64 to !bmodelica.real
+// CHECK: return %[[result_casted]]
+
+func.func @IntegerOperandsAndRealResult(%arg0 : !bmodelica.int, %arg1 : !bmodelica.int) -> !bmodelica.real {
+    %0 = bmodelica.div %arg0, %arg1 : (!bmodelica.int, !bmodelica.int) -> !bmodelica.real
+    func.return %0 : !bmodelica.real
+}
+
+// -----
+
 // CHECK-LABEL: @mlirIndex
 // CHECK-SAME: (%[[arg0:.*]]: index, %[[arg1:.*]]: index) -> index
 // CHECK: %[[result:.*]] = arith.divsi %[[arg0]], %[[arg1]] : index


### PR DESCRIPTION
This PR fixes the conversion of the `bmodelica.div` into the `arith` dialect when the two operands are integers but the result has real type. The operands are first casted to real types too, and then divided using the floating-point division operation. Before this patch, the operands were divided using the integer division operation, thus losing the fractional part.