### PR TITLE
Parse function call in equation section

### DIFF
--- a/include/marco/AST/BaseModelica/AST.h
+++ b/include/marco/AST/BaseModelica/AST.h
@@ -14,6 +14,7 @@
 #include "marco/AST/BaseModelica/AssignmentStatement.h"
 #include "marco/AST/BaseModelica/BreakStatement.h"
 #include "marco/AST/BaseModelica/Call.h"
+#include "marco/AST/BaseModelica/CallEquation.h"
 #include "marco/AST/BaseModelica/Class.h"
 #include "marco/AST/BaseModelica/ComponentReference.h"
 #include "marco/AST/BaseModelica/ComponentReferenceEntry.h"

--- a/include/marco/AST/BaseModelica/ASTNode.h
+++ b/include/marco/AST/BaseModelica/ASTNode.h
@@ -26,6 +26,7 @@ enum class ASTNodeKind : int32_t {
   ClassModification,
   ComponentReferenceEntry,
   Equation,
+  Equation_Call,
   Equation_Equality,
   Equation_For,
   Equation_If,

--- a/include/marco/AST/BaseModelica/CallEquation.h
+++ b/include/marco/AST/BaseModelica/CallEquation.h
@@ -1,0 +1,36 @@
+#ifndef MARCO_AST_BASEMODELICA_CALLEQUATION_H
+#define MARCO_AST_BASEMODELICA_CALLEQUATION_H
+
+#include "marco/AST/BaseModelica/Equation.h"
+
+namespace marco::ast::bmodelica {
+class Expression;
+
+class CallEquation : public Equation {
+public:
+  explicit CallEquation(SourceRange location);
+
+  CallEquation(const CallEquation &other);
+
+  ~CallEquation() override;
+
+  static bool classof(const ASTNode *node) {
+    return node->getKind<ASTNodeKind>() == ASTNodeKind::Equation_Call;
+  }
+
+  std::unique_ptr<ast::ASTNode> clone() const override;
+
+  llvm::json::Value toJSON() const override;
+
+  Expression *getCall();
+
+  const Expression *getCall() const;
+
+  void setCall(std::unique_ptr<ASTNode> node);
+
+private:
+  std::unique_ptr<ASTNode> call;
+};
+} // namespace marco::ast::bmodelica
+
+#endif // MARCO_AST_BASEMODELICA_CALLEQUATION_H

--- a/include/marco/Codegen/Lowering/BaseModelica/BridgeInterface.h
+++ b/include/marco/Codegen/Lowering/BaseModelica/BridgeInterface.h
@@ -105,6 +105,9 @@ public:
   lower(const ast::bmodelica::Equation &equation) = 0;
 
   [[nodiscard]] virtual bool
+  lower(const ast::bmodelica::CallEquation &equation) = 0;
+
+  [[nodiscard]] virtual bool
   lower(const ast::bmodelica::EqualityEquation &equation) = 0;
 
   [[nodiscard]] virtual bool

--- a/include/marco/Codegen/Lowering/BaseModelica/CallEquationLowerer.h
+++ b/include/marco/Codegen/Lowering/BaseModelica/CallEquationLowerer.h
@@ -1,0 +1,21 @@
+#ifndef MARCO_CODEGEN_LOWERING_BASEMODELICA_CALLEQUATIONLOWERER_H
+#define MARCO_CODEGEN_LOWERING_BASEMODELICA_CALLEQUATIONLOWERER_H
+
+#include "marco/AST/BaseModelica/AST.h"
+#include "marco/Codegen/Lowering/BaseModelica/BridgeInterface.h"
+#include "marco/Codegen/Lowering/BaseModelica/Lowerer.h"
+
+namespace marco::codegen::lowering::bmodelica {
+class CallEquationLowerer : public Lowerer {
+public:
+  explicit CallEquationLowerer(BridgeInterface *bridge);
+
+  [[nodiscard]] virtual bool
+  lower(const ast::bmodelica::CallEquation &equation) override;
+
+protected:
+  using Lowerer::lower;
+};
+} // namespace marco::codegen::lowering::bmodelica
+
+#endif // MARCO_CODEGEN_LOWERING_BASEMODELICA_CALLEQUATIONLOWERER_H

--- a/include/marco/Codegen/Lowering/BaseModelica/Lowerer.h
+++ b/include/marco/Codegen/Lowering/BaseModelica/Lowerer.h
@@ -191,6 +191,9 @@ protected:
   lower(const ast::bmodelica::Equation &equation) override;
 
   [[nodiscard]] virtual bool
+  lower(const ast::bmodelica::CallEquation &equation) override;
+
+  [[nodiscard]] virtual bool
   lower(const ast::bmodelica::EqualityEquation &equation) override;
 
   [[nodiscard]] virtual bool

--- a/lib/AST/BaseModelica/CMakeLists.txt
+++ b/lib/AST/BaseModelica/CMakeLists.txt
@@ -8,6 +8,7 @@ set(AST_NODES
     AssignmentStatement.cpp
     BreakStatement.cpp
     Call.cpp
+    CallEquation.cpp
     CallStatement.cpp
     Class.cpp
     ComponentReference.cpp

--- a/lib/AST/BaseModelica/CallEquation.cpp
+++ b/lib/AST/BaseModelica/CallEquation.cpp
@@ -1,0 +1,44 @@
+#include "marco/AST/BaseModelica/CallEquation.h"
+#include "marco/AST/BaseModelica/Expression.h"
+
+using namespace ::marco;
+using namespace ::marco::ast::bmodelica;
+
+namespace marco::ast::bmodelica {
+CallEquation::CallEquation(SourceRange location)
+    : Equation(ASTNodeKind::Equation_Call, std::move(location)) {}
+
+CallEquation::CallEquation(const CallEquation &other) : Equation(other) {
+  setCall(other.call->clone());
+}
+
+CallEquation::~CallEquation() = default;
+
+std::unique_ptr<ASTNode> CallEquation::clone() const {
+  return std::make_unique<CallEquation>(*this);
+}
+
+llvm::json::Value CallEquation::toJSON() const {
+  llvm::json::Object result;
+  result["call"] = getCall()->toJSON();
+
+  addNodeKindToJSON(*this, result);
+  return result;
+}
+
+Expression *CallEquation::getCall() {
+  assert(call != nullptr && "Call not set");
+  return call->cast<Expression>();
+}
+
+const Expression *CallEquation::getCall() const {
+  assert(call != nullptr && "Call not set");
+  return call->cast<Expression>();
+}
+
+void CallEquation::setCall(std::unique_ptr<ASTNode> node) {
+  assert(node->isa<Expression>());
+  call = std::move(node);
+  call->setParent(this);
+}
+} // namespace marco::ast::bmodelica

--- a/lib/Codegen/Lowering/Bridge.cpp
+++ b/lib/Codegen/Lowering/Bridge.cpp
@@ -4,6 +4,7 @@
 #include "marco/Codegen/Lowering/BaseModelica/AssignmentStatementLowerer.h"
 #include "marco/Codegen/Lowering/BaseModelica/BreakStatementLowerer.h"
 #include "marco/Codegen/Lowering/BaseModelica/BridgeInterface.h"
+#include "marco/Codegen/Lowering/BaseModelica/CallEquationLowerer.h"
 #include "marco/Codegen/Lowering/BaseModelica/CallLowerer.h"
 #include "marco/Codegen/Lowering/BaseModelica/CallStatementLowerer.h"
 #include "marco/Codegen/Lowering/BaseModelica/ClassLowerer.h"
@@ -128,6 +129,8 @@ public:
 
   [[nodiscard]] bool lower(const Equation &node) override;
 
+  [[nodiscard]] bool lower(const CallEquation &node) override;
+
   [[nodiscard]] bool lower(const EqualityEquation &node) override;
 
   [[nodiscard]] bool lower(const IfEquation &node) override;
@@ -184,6 +187,7 @@ private:
   std::unique_ptr<SubscriptLowerer> subscriptLowerer;
   std::unique_ptr<EquationSectionLowerer> equationSectionLowerer;
   std::unique_ptr<EquationLowerer> equationLowerer;
+  std::unique_ptr<CallEquationLowerer> callEquationLowerer;
   std::unique_ptr<EqualityEquationLowerer> equalityEquationLowerer;
   std::unique_ptr<ForEquationLowerer> forEquationLowerer;
   std::unique_ptr<IfEquationLowerer> ifEquationLowerer;
@@ -234,6 +238,7 @@ Bridge::Impl::Impl(mlir::MLIRContext &context) {
   this->equationSectionLowerer = std::make_unique<EquationSectionLowerer>(this);
 
   this->equationLowerer = std::make_unique<EquationLowerer>(this);
+  this->callEquationLowerer = std::make_unique<CallEquationLowerer>(this);
 
   this->equalityEquationLowerer =
       std::make_unique<EqualityEquationLowerer>(this);
@@ -466,7 +471,7 @@ std::optional<Results> Bridge::Impl::lower(const Subscript &subscript) {
 }
 
 bool Bridge::Impl::lower(const EquationSection &equationSection) {
-  assert(equationLowerer != nullptr);
+  assert(equationSectionLowerer != nullptr);
   return equationSectionLowerer->lower(equationSection);
 }
 
@@ -475,23 +480,28 @@ bool Bridge::Impl::lower(const Equation &equation) {
   return equationLowerer->lower(equation);
 }
 
+bool Bridge::Impl::lower(const CallEquation &equation) {
+  assert(callEquationLowerer != nullptr);
+  return callEquationLowerer->lower(equation);
+}
+
 bool Bridge::Impl::lower(const EqualityEquation &equation) {
-  assert(equationLowerer != nullptr);
+  assert(equalityEquationLowerer != nullptr);
   return equalityEquationLowerer->lower(equation);
 }
 
 bool Bridge::Impl::lower(const ForEquation &forEquation) {
-  assert(equationLowerer != nullptr);
+  assert(forEquationLowerer != nullptr);
   return forEquationLowerer->lower(forEquation);
 }
 
 bool Bridge::Impl::lower(const IfEquation &equation) {
-  assert(equationLowerer != nullptr);
+  assert(ifEquationLowerer != nullptr);
   return ifEquationLowerer->lower(equation);
 }
 
 bool Bridge::Impl::lower(const WhenEquation &equation) {
-  assert(equationLowerer != nullptr);
+  assert(whenEquationLowerer != nullptr);
   return whenEquationLowerer->lower(equation);
 }
 

--- a/lib/Codegen/Lowering/CMakeLists.txt
+++ b/lib/Codegen/Lowering/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     AssignmentStatementLowerer.cpp
     BreakStatementLowerer.cpp
     Bridge.cpp
+    CallEquationLowerer.cpp
     CallLowerer.cpp
     CallStatementLowerer.cpp
     ClassDependencyGraph.cpp

--- a/lib/Codegen/Lowering/CallEquationLowerer.cpp
+++ b/lib/Codegen/Lowering/CallEquationLowerer.cpp
@@ -1,0 +1,19 @@
+#include "marco/Codegen/Lowering/BaseModelica/CallEquationLowerer.h"
+
+using namespace ::marco;
+using namespace ::marco::codegen;
+using namespace ::mlir::bmodelica;
+
+namespace marco::codegen::lowering::bmodelica {
+CallEquationLowerer::CallEquationLowerer(BridgeInterface *bridge)
+    : Lowerer(bridge) {}
+
+bool CallEquationLowerer::lower(const ast::bmodelica::CallEquation &equation) {
+  mlir::Location location = loc(equation.getLocation());
+
+  mlir::emitWarning(location,
+                    "lowering of call equations is not yet implemented");
+
+  return true;
+}
+} // namespace marco::codegen::lowering::bmodelica

--- a/lib/Codegen/Lowering/EquationLowerer.cpp
+++ b/lib/Codegen/Lowering/EquationLowerer.cpp
@@ -8,6 +8,10 @@ namespace marco::codegen::lowering::bmodelica {
 EquationLowerer::EquationLowerer(BridgeInterface *bridge) : Lowerer(bridge) {}
 
 bool EquationLowerer::lower(const ast::bmodelica::Equation &equation) {
+  if (auto casted = equation.dyn_cast<ast::bmodelica::CallEquation>()) {
+    return lower(*casted);
+  }
+
   if (auto casted = equation.dyn_cast<ast::bmodelica::EqualityEquation>()) {
     return lower(*casted);
   }

--- a/lib/Codegen/Lowering/Lowerer.cpp
+++ b/lib/Codegen/Lowering/Lowerer.cpp
@@ -335,6 +335,10 @@ bool Lowerer::lower(const ast::bmodelica::Equation &node) {
   return bridge->lower(node);
 }
 
+bool Lowerer::lower(const ast::bmodelica::CallEquation &node) {
+  return bridge->lower(node);
+}
+
 bool Lowerer::lower(const ast::bmodelica::EqualityEquation &node) {
   return bridge->lower(node);
 }

--- a/lib/Parser/BaseModelica/Parser.cpp
+++ b/lib/Parser/BaseModelica/Parser.cpp
@@ -585,16 +585,29 @@ ParseResult<std::unique_ptr<ASTNode>> Parser::parseEquation() {
   }
 
   TRY(lhs, parseExpression());
-  EXPECT(TokenKind::EqualityOperator);
-  TRY(rhs, parseExpression());
+
+  if (lookahead[0].isa<TokenKind::EqualityOperator>()) {
+    EXPECT(TokenKind::EqualityOperator);
+    TRY(rhs, parseExpression());
+    accept<TokenKind::String>();
+
+    SourceRange loc = (*lhs)->getLocation();
+    loc.end = getLocation().end;
+
+    auto result = std::make_unique<EqualityEquation>(loc);
+    result->setLhsExpression(std::move(*lhs));
+    result->setRhsExpression(std::move(*rhs));
+    return static_cast<std::unique_ptr<ASTNode>>(std::move(result));
+  }
+
+  // Function call (e.g., assertion).
   accept<TokenKind::String>();
 
   SourceRange loc = (*lhs)->getLocation();
   loc.end = getLocation().end;
 
-  auto result = std::make_unique<EqualityEquation>(loc);
-  result->setLhsExpression(std::move(*lhs));
-  result->setRhsExpression(std::move(*rhs));
+  auto result = std::make_unique<CallEquation>(loc);
+  result->setCall(std::move(*lhs));
   return static_cast<std::unique_ptr<ASTNode>>(std::move(result));
 }
 

--- a/unittest/Parser/BaseModelica/Parser.cpp
+++ b/unittest/Parser/BaseModelica/Parser.cpp
@@ -354,7 +354,7 @@ TEST(Parser, algorithm_statementsCount) {
   EXPECT_EQ((*node)->cast<Algorithm>()->getStatements().size(), 3);
 }
 
-TEST(Parser, equalityEquation) {
+TEST(Parser, equation_equality) {
   auto str = R"(y = x)";
 
   auto parser = StringParser::get(str);
@@ -383,6 +383,26 @@ TEST(Parser, equalityEquation) {
   EXPECT_EQ(rhs->cast<ComponentReference>()->getElement(0)->getName(), "x");
   EXPECT_EQ(
       rhs->cast<ComponentReference>()->getElement(0)->getNumOfSubscripts(), 0);
+}
+
+TEST(Parser, equation_call) {
+  auto str = R"(foo(arg1, arg2))";
+
+  auto parser = StringParser::get(str);
+
+  auto node = parser->parseEquation();
+  ASSERT_TRUE(node.has_value());
+
+  EXPECT_EQ((*node)->getLocation().begin.line, 1);
+  EXPECT_EQ((*node)->getLocation().begin.column, 1);
+
+  EXPECT_EQ((*node)->getLocation().end.line, 1);
+  EXPECT_EQ((*node)->getLocation().end.column, 15);
+
+  ASSERT_TRUE((*node)->isa<CallEquation>());
+
+  auto call = (*node)->cast<CallEquation>()->getCall();
+  ASSERT_TRUE(call->isa<Call>());
 }
 
 TEST(Parser, statement_assignment) {


### PR DESCRIPTION
The MR adds the support at the AST level for equations that consist in just function calls (e.g., an assertion).
The code generation for this equation is left as future work and a warning is emitted to highlight the equation being ignored during the lowering process.